### PR TITLE
Undo / redo for level INF data

### DIFF
--- a/TheForceEngine/TFE_Editor/LevelEditor/editCommon.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/editCommon.cpp
@@ -44,7 +44,8 @@ namespace LevelEditor
 				if (sector)
 				{
 					selection_clearHovered();
-					edit_deleteVertex(sector->id, featureIndex, LName_DeleteVertex);
+					//edit_deleteVertex(sector->id, featureIndex, LName_DeleteVertex);
+					edit_deleteVertices();
 				}
 			} break;
 			case LEDIT_WALL:
@@ -83,8 +84,16 @@ namespace LevelEditor
 			{
 				if (sector)
 				{
+					// Multidelete
+					std::vector<s32>sectorIds;
+					FeatureId* sectors;
+					u32 sectorCount = selection_getList(sectors, SEL_SECTOR);
+					for (u32 i = 0; i < sectorCount; i++, sectors++)
+					{
+						sectorIds.push_back((s32)*sectors);
+					}
 					selection_clearHovered();
-					edit_deleteSector(sector->id);
+					edit_deleteSectors(sectorIds);
 				}
 			} break;
 			case LEDIT_ENTITY:

--- a/TheForceEngine/TFE_Editor/LevelEditor/editVertex.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/editVertex.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <unordered_map>
 
 using namespace TFE_Editor;
 using namespace TFE_Jedi;
@@ -37,6 +38,13 @@ namespace LevelEditor
 		s32 vertexIndex;
 		s32 leftWall, rightWall;
 	};
+
+	struct StrandResult
+	{
+		std::vector<s32> strand;
+		bool isCircuit;
+	};
+
 	static std::vector<VertexWallGroup> s_vertexWallGroups;
 	static std::vector<EditorSector> s_sectorSnapshot;
 	static std::vector<s32> s_deltaSectors;
@@ -216,6 +224,443 @@ namespace LevelEditor
 			// Search for other sectors based on the range.
 			findHoveredVertexOutside({ worldPos.x, s_grid.height, worldPos.z }, s_zoom2d * 16.0f, false);
 		}
+	}
+
+	inline s32 getPrevWall(EditorSector* sector, s32 wallId)
+	{
+		s32 targetVtx = sector->walls[wallId].idx[0];
+		for (s32 i = 0; i < sector->walls.size(); i++)
+		{
+			//if (i == wallId) { continue; }
+			if (sector->walls[i].idx[1] == targetVtx)
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	inline s32 getNextWall(EditorSector* sector, s32 wallId)
+	{
+		s32 targetVtx = sector->walls[wallId].idx[1];
+		for (s32 i = 0; i < sector->walls.size(); i++)
+		{
+			//if (i == wallId) { continue; }
+			if (sector->walls[i].idx[0] == targetVtx)
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	// Return the loops of vtx that make up exterior and interior walls
+	//WallVertMap getSectorWallLoopsOrdered(EditorSector* sector)
+	//{
+	//	WallVertMap map = { sector, std::vector<s32>(), std::vector<s32>(), std::vector<s32>(), std::vector<s32>() };
+	//	map.walls.reserve(sector->walls.size());
+	//	map.vtx.reserve(sector->vtx.size());
+
+	//	EditorWall* wall = &sector->walls[0];
+	//	map.walls.push_back(0);
+	//	map.wallStarts.push_back(0);
+	//	map.vtx.push_back(wall->idx[0]);
+	//	map.vtx.push_back(wall->idx[1]);
+	//	map.vtxStarts.push_back(wall->idx[0]);
+
+	//	for (s32 i = 1; i < sector->walls.size(); i++)
+	//	{
+	//		s32 nextWall = getNextWall(sector, map.walls.back());
+	//		if (nextWall == map.wallStarts.back()) // Enclosed a loop
+	//		{
+	//			map.vtx.pop_back(); // This will be a dupe
+	//			// Is this the exterior wall?
+	//			std::vector<Vec2f> verts;
+	//			for (const s32 index : map.vtx) { verts.push_back(sector->vtx[index]); }
+	//			if (!(TFE_Polygon::signedArea((s32)map.vtx.size(), verts.data()) > 0.0f))
+	//			{
+	//				// Interior
+
+	//			}
+
+	//		}
+	//		else if (nextWall == -1) // Dead end. Loop not enclosed, work back from last start?
+	//		{
+
+	//		}
+	//		else
+	//		{
+	//			map.walls.push_back(nextWall);
+	//			map.vtx.push_back(sector->walls[nextWall].idx[1]);
+	//		}
+	//	}
+
+	//	if (getNextWall(sector, map.walls.back()) == map.wallStarts.back()) // The wall loop completes
+	//	{
+	//		map.vtx.pop_back();
+	//	}
+	//	else // Dead end, but no more data to work with
+	//	{
+
+	//	}
+	//	return map;
+	//}
+
+	s32 findWallByVertId(EditorSector* sector, s32 vert)
+	{
+		EditorWall* wall = sector->walls.data();
+		for (s32 i = 0; i < sector->walls.size(); i++, wall++)
+		{
+			if (wall->idx[0] == vert)
+			{
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	s32 findPrevVtx(EditorSector* sector, s32 vert)
+	{
+		EditorWall* wall = sector->walls.data();
+		size_t wallCount = sector->walls.size();
+		for (size_t i = 0; i < wallCount; i++, wall++)
+		{
+			if (wall->idx[1] == vert)
+			{
+				return wall->idx[0];
+			}
+		}
+
+		return -1;
+	}
+
+	s32 findNextVtx(EditorSector* sector, s32 vert)
+	{
+		EditorWall* wall = sector->walls.data();
+		size_t wallCount = sector->walls.size();
+		for (size_t i = 0; i < wallCount; i++, wall++)
+		{
+			if (wall->idx[0] == vert)
+			{
+				return wall->idx[1];
+			}
+		}
+
+		return -1;
+	}
+
+	bool isIdInList(std::vector<s32>& list, s32 id)
+	{
+		for (size_t i = 0; i < list.size(); i++)
+		{
+			if (list[i] == id) { return true; }
+		}
+		return false;
+	}
+
+	StrandResult createStrandOfLinkedVtx(EditorSector* sector, std::vector<s32>& vertIds, s32 startVert)
+	{
+		s32 currentVtx = startVert;
+		s32 leftmostVtx = startVert;
+		s32 rightmostVtx = startVert;
+
+		size_t vtxCount = sector->vtx.size();
+		size_t vidCount = vertIds.size();
+		size_t wallCount = sector->walls.size();
+
+		StrandResult result = {};
+		result.strand.push_back(startVert);
+
+		// Work leftward
+		for (size_t left = 0; left < vtxCount; left++)
+		{
+			leftmostVtx = findPrevVtx(sector, currentVtx);
+			if (leftmostVtx == -1)
+			{
+				// Dead end
+				break;
+			}
+			else if (leftmostVtx == startVert)
+			{
+				// Completed a circuit. Return early no need to go forward.
+				result.isCircuit = true;
+				return result;
+			}
+			else
+			{
+				if (isIdInList(vertIds, leftmostVtx))
+				{
+					currentVtx = leftmostVtx;
+					result.strand.insert(result.strand.begin(), leftmostVtx);
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+
+		// Work rightward
+		currentVtx = rightmostVtx;
+		for (size_t right = 0; right < vtxCount; right++)
+		{
+			rightmostVtx = findNextVtx(sector, currentVtx);
+			if (rightmostVtx == -1)
+			{
+				break;
+			}
+			else
+			{
+				if (isIdInList(vertIds, rightmostVtx))
+				{
+					currentVtx = rightmostVtx;
+					result.strand.push_back(rightmostVtx);
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	void edit_multidelVerts(EditorSector* sector, std::vector<s32>& vertIds, std::vector<s32>& deletedSectors)
+	{
+		std::vector<s32> strand;
+
+		//std::vector<s32> extraSectorsForDelete;
+
+		std::vector<IndexPair> vertIdMap;
+
+		for (const s32 id : vertIds) { vertIdMap.push_back({ id, 0 }); }
+
+		// find an available id, search backwards to find the wall that will be re-idx1'd, then forwards to find the end
+
+		while (strand.size() < vertIds.size())
+		{
+			for (size_t i = 0; i < vertIdMap.size(); i++)
+			{
+				if (vertIdMap[i].i1 == 0) // We have a free id
+				{
+					s32 currentVtx = vertIdMap[i].i0;
+					StrandResult returnedStrand = createStrandOfLinkedVtx(sector, vertIds, currentVtx);
+					strand.insert(strand.end(), returnedStrand.strand.begin(), returnedStrand.strand.end());
+
+					assert(returnedStrand.strand.size() > 0);
+
+					// Update the geometry based on this strand
+					// 1. Find the walls that attach to the start and ends of the strands
+
+					if (returnedStrand.isCircuit)
+					{
+						// If exterior wall, delete sector. Else, degen the walls
+						std::vector<Vec2f> vtx;
+						for (size_t j = 0; j < returnedStrand.strand.size(); j++)
+						{
+							vtx.push_back(sector->vtx[returnedStrand.strand[j]]);
+						}
+
+						s32 vtxCount = (s32)vtx.size();
+						if (!(TFE_Polygon::signedArea(vtxCount, vtx.data()) > 0.0f))
+						{
+							EditorWall* wall = sector->walls.data();
+							size_t wallCount = sector->walls.size();
+
+							for (size_t j = 0; j < wallCount; j++, wall++)
+							{
+								if (wall->idx[0] == currentVtx)
+								{
+									s32 currentWall = (s32)j;
+									std::vector<s32> wallsToDelete;
+									for (size_t k = 0; k < returnedStrand.strand.size(); k++)
+									{
+										currentWall = getNextWall(sector, currentWall);
+										assert(currentWall >= 0);
+										wallsToDelete.push_back(currentWall);
+									}
+
+									for (const s32 id : wallsToDelete) { sector->walls[id].idx[0] = sector->walls[id].idx[1]; }
+
+									break;
+								}
+							}
+						}
+						else
+						{
+							deletedSectors.push_back(sector->id);
+						}
+					}
+					else
+					{
+						s32 startWall = -1;
+						s32 alternateWall = -1;
+						s32 endWall = -1;
+						bool deadEndStart = false;
+						bool deadEndEnd = false;
+						size_t wallCount = sector->walls.size();
+						EditorWall* wall = sector->walls.data();
+						for (size_t start = 0; start < wallCount; start++, wall++)
+						{
+							if (wall->idx[0] == returnedStrand.strand.front())
+							{
+								alternateWall = (s32)start;
+							}
+							if (wall->idx[1] == returnedStrand.strand.front())
+							{
+								startWall = (s32)start;
+								break;
+							}
+						}
+						if (startWall == -1)
+						{
+							// Vert is strand start deadend
+							deadEndStart = true;
+							startWall = alternateWall;
+						}
+
+						wall = sector->walls.data();
+						for (size_t end = 0; end < wallCount; end++, wall++)
+						{
+							if (wall->idx[1] == returnedStrand.strand.back())
+							{
+								alternateWall = (s32)end;
+							}
+							if (wall->idx[0] == returnedStrand.strand.back())
+							{
+								endWall = (s32)end;
+								break;
+							}
+						}
+						if (endWall == -1)
+						{
+							// Vert is strand end deadend
+							deadEndEnd = true;
+						}
+
+						// 1a test if the strand is a circuit
+						if (!deadEndStart && !deadEndEnd)
+						{
+							if (sector->walls[startWall].idx[0] == sector->walls[endWall].idx[1])
+							{
+								LE_WARNING("Circuit");
+							}
+						}
+
+						// 2. Make any interim walls degenerate. Compile a list to avoid editing idx data while walking
+						s32 currentWall = startWall;
+						std::vector<s32> removeWalls;
+						for (size_t w = 0; w < returnedStrand.strand.size() - 1; w++)
+						{
+							currentWall = getNextWall(sector, currentWall);
+							if (currentWall >= 0) { removeWalls.push_back(currentWall); }
+						}
+						for (const s32 id : removeWalls)
+						{
+							sector->walls[id].idx[0] = sector->walls[id].idx[1];
+						}
+
+						// 3. Connect start and end walls dependant on deadends detected
+						if (deadEndEnd || deadEndStart)
+						{
+							// No end wall to stitch to, so kill startwall
+							// or start wall is part of the cull
+							sector->walls[startWall].idx[0] = sector->walls[startWall].idx[1];
+						}
+						else
+						{
+							sector->walls[startWall].idx[1] = sector->walls[endWall].idx[1];
+							sector->walls[endWall].idx[1] = sector->walls[endWall].idx[0];
+						}
+					}
+
+					// 4. mark found ids in the map
+					for (size_t strandIndex = 0; strandIndex < returnedStrand.strand.size(); strandIndex++)
+					{
+						for (size_t mapIndex = 0; mapIndex < vertIdMap.size(); mapIndex++)
+						{
+							if (returnedStrand.strand[strandIndex] == vertIdMap[mapIndex].i0) { vertIdMap[mapIndex].i1 = 1; }
+						}
+					}
+
+				}
+			}
+		}
+	}
+
+	// Delete selected vertices 
+	void edit_deleteVertices()
+	{
+		// Save a snapshot *before* delete.
+		level_createLevelSectorSnapshotSameAssets(s_sectorSnapshot);
+
+		std::vector<s32> deletedSectors;
+		std::unordered_map<s32, std::vector<s32>> sectorVtxMap;
+
+		s32 featureIndex;
+		FeatureId* id;
+		u32 vtxCount = selection_getList(id, SEL_VERTEX);
+
+		// Fill the hashmap with sectors and feature (vtx) ids.
+		for (size_t i = 0; i < vtxCount; i++, id++)
+		{
+			EditorSector* sector = unpackFeatureId(*id, &featureIndex);
+			if (sectorVtxMap.count(sector->id) > 0)
+			{
+				sectorVtxMap.at(sector->id).push_back(featureIndex);
+			}
+			else
+			{
+				sectorVtxMap.emplace(sector->id, std::vector<s32>());
+				sectorVtxMap.at(sector->id).push_back(featureIndex);
+			}
+		}
+
+
+		for (auto& entry : sectorVtxMap)
+		{
+			s32 sectorId = entry.first;
+			if (entry.second.size() > s_level.sectors[sectorId].vtx.size() - 2)
+			{
+				// Two or less verts would be left in the sector. Delete it.
+				deletedSectors.push_back(sectorId);
+			}
+		}
+
+		std::vector<s32> cleanSectorList;
+		std::vector<EditorSector*> changedSectorList;
+		// Clear out any keys for deleted sectors
+		for (const s32 id : deletedSectors) { sectorVtxMap.erase(id); }
+
+		// Test some deletes
+		for (auto entry : sectorVtxMap)
+		{
+			EditorSector* sector = &s_level.sectors[entry.first];
+			// WallVertMap wvMap = getSectorWallLoopsOrdered(sector);
+			if (entry.second.size() > 0)
+			{
+				edit_multidelVerts(sector, entry.second, deletedSectors);
+				cleanSectorList.push_back(sector->id);
+				changedSectorList.push_back(sector);
+			}
+		}
+
+		edit_cleanSectorList(cleanSectorList, false);
+
+		edit_deleteSectors(deletedSectors, false);
+
+		// Remove any invalid sectors.
+		deleteInvalidSectors(changedSectorList);
+
+		// When deleting features, we need to clear out the selections.
+		edit_clearSelections();
+
+		// Get the sectors that changed due to deletion and build a limited snapshot from that.
+		level_getLevelSnapshotDelta(s_deltaSectors, s_sectorSnapshot);
+		cmd_sectorSnapshot(LName_DeleteVertex, s_deltaSectors);
 	}
 	
 	// Delete a vertex.

--- a/TheForceEngine/TFE_Editor/LevelEditor/editVertex.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/editVertex.h
@@ -18,6 +18,7 @@ namespace LevelEditor
 	void findHoveredVertex2d(EditorSector* hoveredSector, Vec2f worldPos);
 	void vertexComputeDragSelect();
 	void edit_deleteVertex(s32 sectorId, s32 vertexIndex, u32 nameId);
+	void edit_deleteVertices();
 
 	// Transforms
 	void edit_setVertexPos(FeatureId id, Vec2f pos);

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.cpp
@@ -2,6 +2,7 @@
 #include "levelDataSnapshot.h"
 #include "sharedState.h"
 #include "guidelines.h"
+#include "levelEditorInf.h"
 #include <TFE_Editor/snapshotReaderWriter.h>
 #include <TFE_Editor/history.h>
 #include <TFE_Editor/errorMessages.h>
@@ -205,6 +206,135 @@ namespace LevelEditor
 		writeData(guideline->offsets.data(), sizeof(f32) * offsetCount);
 	}
 
+	void writeInfElevatorToSnapshot(const Editor_InfElevator* infElevator)
+	{
+		const s32 slaveCount = (s32)infElevator->slaves.size();
+		const s32 stopCount = (s32)infElevator->stops.size();
+
+		writeU32(infElevator->classId);
+		writeU32(infElevator->type);
+		writeU32(infElevator->overrideSet);
+		writeS32(infElevator->start);
+		writeF32(infElevator->speed);
+		writeF32(infElevator->angle);
+		writeU32(infElevator->flags);
+		writeData(infElevator->key, sizeof(KeyItem) * 2);
+		writeData(&infElevator->center, sizeof(Vec2f));
+		writeString(infElevator->sounds[0]);
+		writeString(infElevator->sounds[1]);
+		writeString(infElevator->sounds[2]);
+		writeU8(infElevator->master);
+		writeS32(infElevator->eventMask);
+		writeS32(infElevator->entityMask);
+		writeS32(slaveCount);
+		writeS32(stopCount);
+
+		// Each slave & stop is of variable length
+		for (s32 i = 0; i < slaveCount; i++)
+		{
+			writeString(infElevator->slaves[i].name);
+			writeF32(infElevator->slaves[i].angleOffset);
+		}
+
+		for (s32 i = 0; i < stopCount; i++)
+		{
+			const s32 adjoinCount = (s32)infElevator->stops[i].adjoinCmd.size();
+			const s32 textureCount = (s32)infElevator->stops[i].textureCmd.size();
+			const s32 messageCount = (s32)infElevator->stops[i].msg.size();
+			const s32 scriptCount = (s32)infElevator->stops[i].scriptCall.size();
+			writeU32(infElevator->stops[i].overrideSet);
+			writeU8(infElevator->stops[i].relative);
+			writeF32(infElevator->stops[i].value);
+			writeString(infElevator->stops[i].fromSectorFloor);
+			writeU32(infElevator->stops[i].delayType);
+			writeF32(infElevator->stops[i].delay);
+			writeString(infElevator->stops[i].page);
+			writeS32(adjoinCount);
+			writeS32(textureCount);
+			writeS32(messageCount);
+			writeS32(scriptCount);
+			for (s32 j = 0; j < adjoinCount; j++)
+			{
+				writeString(infElevator->stops[i].adjoinCmd[j].sector0);
+				writeString(infElevator->stops[i].adjoinCmd[j].sector1);
+				writeS32(infElevator->stops[i].adjoinCmd[j].wallIndex0);
+				writeS32(infElevator->stops[i].adjoinCmd[j].wallIndex1);
+			}
+			for (s32 j = 0; j < textureCount; j++)
+			{
+				writeString(infElevator->stops[i].textureCmd[j].donorSector);
+				writeU8(infElevator->stops[i].textureCmd[j].fromCeiling);
+			}
+			for (s32 j = 0; j < messageCount; j++)
+			{
+				writeString(infElevator->stops[i].msg[j].targetSector);
+				writeS32(infElevator->stops[i].msg[j].targetWall);
+				writeU32(infElevator->stops[i].msg[j].type);
+				writeU32(infElevator->stops[i].msg[j].eventFlags);
+				writeU32(infElevator->stops[i].msg[j].arg[0]);
+				writeU32(infElevator->stops[i].msg[j].arg[1]);
+			}
+			for (s32 j = 0; j < scriptCount; j++)
+			{
+				writeString(infElevator->stops[i].scriptCall[j].funcName);
+				writeString(infElevator->stops[i].scriptCall[j].arg[0].value);
+				writeString(infElevator->stops[i].scriptCall[j].arg[1].value);
+				writeString(infElevator->stops[i].scriptCall[j].arg[2].value);
+				writeString(infElevator->stops[i].scriptCall[j].arg[3].value);
+			}
+		}
+	}
+
+	void writeInfTriggerToSnapshot(const Editor_InfTrigger* infTrigger)
+	{
+		writeU32(infTrigger->classId);
+		writeU32(infTrigger->type);
+		writeU32(infTrigger->overrideSet);
+		const s32 clientCount = (s32)infTrigger->clients.size();
+		writeS32(clientCount);
+		for (s32 i = 0; i < clientCount; i++)
+		{
+			writeString(infTrigger->clients[i].targetSector);
+			writeS32(infTrigger->clients[i].targetWall);
+			writeS32(infTrigger->clients[i].eventMask);
+		}
+		writeU32(infTrigger->cmd);
+		writeData(&infTrigger->arg, sizeof(u32) * 2);
+		writeString(infTrigger->sound);
+		writeU8(infTrigger->master);
+		writeU32(infTrigger->textId);
+		writeS32(infTrigger->eventMask);
+		writeS32(infTrigger->entityMask);
+		writeU32(infTrigger->event);
+	}
+
+	void writeInfTeleporterToSnapshot(const Editor_InfTeleporter* infTeleporter)
+	{
+		writeU32(infTeleporter->classId);
+		writeU32(infTeleporter->type);
+		writeString(infTeleporter->target);
+		writeData(&infTeleporter->dstPos, sizeof(Vec3f));
+		writeF32(infTeleporter->dstAngle);
+	}
+
+	void writeInfItemToSnapshot(const Editor_InfItem* infItem)
+	{
+		const s32 classCount = (s32)infItem->classData.size();
+
+		writeString(infItem->name);
+		writeS32(infItem->wallNum);
+		writeS32(classCount);
+		for (s32 i = 0; i < classCount; i++)
+		{
+			// classData are ptrs to heap data. Store the index for snapshotting, ref new ptr addresses when unpacking.
+			Editor_InfClass* classPtr = infItem->classData[i];
+			s32 classIndex = getClassIndex(classPtr->classId, classPtr);
+			assert(classIndex >= 0);
+			writeU32(infItem->classData[i]->classId);
+			writeS32(classIndex);
+		}
+	}
+
 	void readEntityFromSnapshot(Entity* entity)
 	{
 		entity->id = readS32();
@@ -302,5 +432,123 @@ namespace LevelEditor
 		readData(guideline->offsets.data(), sizeof(f32) * offsetCount);
 
 		guideline_computeSubdivision(guideline);
+	}
+
+	void readInfItemFromSnapshot(Editor_InfItem* infItem)
+	{
+		readString(infItem->name);
+		infItem->wallNum = readS32();
+		s32 classCount = readS32();
+		infItem->classData.resize(classCount);
+	}
+
+	void readInfElevatorFromSnapshot(Editor_InfElevator* infElevator)
+	{
+		infElevator->classId = (Editor_InfItemClass)readU32();
+		infElevator->type = (Editor_InfElevType)readU32();
+		infElevator->overrideSet = (Editor_InfElevatorOverride)readU32();
+		infElevator->start = readS32();
+		infElevator->speed = readF32();
+		infElevator->angle = readF32();
+		infElevator->flags = readU32();
+		readData(infElevator->key, sizeof(KeyItem) * 2);
+		readData(&infElevator->center, sizeof(Vec2f));
+		readString(infElevator->sounds[0]);
+		readString(infElevator->sounds[1]);
+		readString(infElevator->sounds[2]);
+		infElevator->master = (bool)readU8();
+		infElevator->eventMask = readS32();
+		infElevator->entityMask = readS32();
+		const s32 slaveCount = readS32();
+		const s32 stopCount = readS32();
+		infElevator->slaves.resize(slaveCount);
+		infElevator->stops.resize(stopCount);
+		
+		// Each slave & stop is of variable length
+		for (s32 i = 0; i < slaveCount; i++)
+		{
+			readString(infElevator->slaves[i].name);
+			infElevator->slaves[i].angleOffset = readF32();
+		}
+
+		for (s32 i = 0; i < stopCount; i++)
+		{
+			infElevator->stops[i].overrideSet = readU32();
+			infElevator->stops[i].relative = (bool)readU8();
+			infElevator->stops[i].value = readF32();
+			readString(infElevator->stops[i].fromSectorFloor);
+			infElevator->stops[i].delayType = (Editor_InfStopDelayType)readU32();
+			infElevator->stops[i].delay = readF32();
+			readString(infElevator->stops[i].page);
+			const s32 adjoinCount = readS32();
+			const s32 textureCount = readS32();
+			const s32 messageCount = readS32();
+			const s32 scriptCount = readS32();
+			infElevator->stops[i].adjoinCmd.resize(adjoinCount);
+			infElevator->stops[i].textureCmd.resize(textureCount);
+			infElevator->stops[i].msg.resize(messageCount);
+			infElevator->stops[i].scriptCall.resize(scriptCount);
+			for (s32 j = 0; j < adjoinCount; j++)
+			{
+				readString(infElevator->stops[i].adjoinCmd[j].sector0);
+				readString(infElevator->stops[i].adjoinCmd[j].sector1);
+				infElevator->stops[i].adjoinCmd[j].wallIndex0 = readS32();
+				infElevator->stops[i].adjoinCmd[j].wallIndex1 = readS32();
+			}
+			for (s32 j = 0; j < textureCount; j++)
+			{
+				readString(infElevator->stops[i].textureCmd[j].donorSector);
+				infElevator->stops[i].textureCmd[j].fromCeiling = (bool)readU8();
+			}
+			for (s32 j = 0; j < messageCount; j++)
+			{
+				readString(infElevator->stops[i].msg[j].targetSector);
+				infElevator->stops[i].msg[j].targetWall = readS32();
+				infElevator->stops[i].msg[j].type = (Editor_InfMessageType)readU32();
+				infElevator->stops[i].msg[j].eventFlags = readU32();
+				infElevator->stops[i].msg[j].arg[0] = readU32();
+				infElevator->stops[i].msg[j].arg[1] = readU32();
+			}
+			for (s32 j = 0; j < scriptCount; j++)
+			{
+				readString(infElevator->stops[i].scriptCall[j].funcName);
+				readString(infElevator->stops[i].scriptCall[j].arg[0].value);
+				readString(infElevator->stops[i].scriptCall[j].arg[1].value);
+				readString(infElevator->stops[i].scriptCall[j].arg[2].value);
+				readString(infElevator->stops[i].scriptCall[j].arg[3].value);
+			}
+		}
+	}
+
+	void readInfTriggerFromSnapshot(Editor_InfTrigger* infTrigger)
+	{
+		infTrigger->classId = (Editor_InfItemClass)readU32();
+		infTrigger->type = (TriggerType)readU32();
+		infTrigger->overrideSet = readU32();
+		const s32 clientCount = readS32();
+		infTrigger->clients.resize(clientCount);
+		for (s32 i = 0; i < clientCount; i++)
+		{
+			readString(infTrigger->clients[i].targetSector);
+			infTrigger->clients[i].targetWall = readS32();
+			infTrigger->clients[i].eventMask = readS32();
+		}
+		infTrigger->cmd = (Editor_InfMessageType)readU32();
+		readData(&infTrigger->arg, sizeof(u32) * 2);
+		readString(infTrigger->sound);
+		infTrigger->master = (bool)readU8();
+		infTrigger->textId = readU32();
+		infTrigger->eventMask = readS32();
+		infTrigger->entityMask = readS32();
+		infTrigger->event = readU32();
+	}
+
+	void readInfTeleporterFromSnapshot(Editor_InfTeleporter* infTeleporter)
+	{
+		infTeleporter->classId = (Editor_InfItemClass)readU32();
+		infTeleporter->type = (TeleportType)readU32();
+		readString(infTeleporter->target);
+		readData(&infTeleporter->dstPos, sizeof(Vec3f));
+		infTeleporter->dstAngle = readF32();
 	}
 }

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.cpp
@@ -150,6 +150,13 @@ namespace LevelEditor
 		writeData(sector->obj.data(), u32(sizeof(EditorObject) * sector->obj.size()));
 	}
 
+	void writeINFWallTrackToSnapshot(const INFWallTrack* wt)
+	{
+		writeString(wt->name);
+		writeS32(wt->oldWall);
+		writeS32(wt->newWall);
+	}
+
 	void writeSectorAttribSnapshot(const EditorSector* sector)
 	{
 		writeU32(sector->groupId);
@@ -375,6 +382,13 @@ namespace LevelEditor
 		readData(sector->vtx.data(), u32(sizeof(Vec2f) * sector->vtx.size()));
 		readData(sector->walls.data(), u32(sizeof(EditorWall) * sector->walls.size()));
 		readData(sector->obj.data(), u32(sizeof(EditorObject) * sector->obj.size()));
+	}
+
+	void readINFWallTrackFromSnapshot(INFWallTrack* wallTrack)
+	{
+		readString(wallTrack->name);
+		wallTrack->oldWall = readS32();
+		wallTrack->newWall = readS32();
 	}
 
 	void readFromSectorAttribSnapshot(EditorSector* sector)

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.h
@@ -10,6 +10,7 @@
 #include "entity.h"
 #include "groups.h"
 #include "note.h"
+#include "levelEditorInf.h"
 #include <TFE_Editor/EditorAsset/editorAsset.h>
 #include <TFE_Editor/EditorAsset/editorTexture.h>
 #include <TFE_Editor/editorProject.h>
@@ -39,10 +40,18 @@ namespace LevelEditor
 	void writeSectorAttribSnapshot(const EditorSector* sector);
 	void writeLevelNoteToSnapshot(const LevelNote* note);
 	void writeGuidelineToSnapshot(const Guideline* guideline);
+	void writeInfElevatorToSnapshot(const Editor_InfElevator* infElevator);
+	void writeInfTriggerToSnapshot(const Editor_InfTrigger* infTrigger);
+	void writeInfTeleporterToSnapshot(const Editor_InfTeleporter* infTeleporter);
+	void writeInfItemToSnapshot(const Editor_InfItem* infItem);
 
 	void readEntityFromSnapshot(Entity* entity);
 	void readSectorFromSnapshot(EditorSector* sector);
 	void readFromSectorAttribSnapshot(EditorSector* sector);
 	void readLevelNoteFromSnapshot(LevelNote* note);
 	void readGuidelineFromSnapshot(Guideline* guideline);
+	void readInfElevatorFromSnapshot(Editor_InfElevator* infElevator);
+	void readInfTriggerFromSnapshot(Editor_InfTrigger* infTrigger);
+	void readInfTeleporterFromSnapshot(Editor_InfTeleporter* infTeleporter);
+	void readInfItemFromSnapshot(Editor_InfItem* infItem);
 }

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.h
@@ -44,6 +44,7 @@ namespace LevelEditor
 	void writeInfTriggerToSnapshot(const Editor_InfTrigger* infTrigger);
 	void writeInfTeleporterToSnapshot(const Editor_InfTeleporter* infTeleporter);
 	void writeInfItemToSnapshot(const Editor_InfItem* infItem);
+	void writeINFWallTrackToSnapshot(const INFWallTrack* wt);
 
 	void readEntityFromSnapshot(Entity* entity);
 	void readSectorFromSnapshot(EditorSector* sector);
@@ -54,4 +55,5 @@ namespace LevelEditor
 	void readInfTriggerFromSnapshot(Editor_InfTrigger* infTrigger);
 	void readInfTeleporterFromSnapshot(Editor_InfTeleporter* infTeleporter);
 	void readInfItemFromSnapshot(Editor_InfItem* infItem);
+	void readINFWallTrackFromSnapshot(INFWallTrack* wallTrack);
 }

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditor.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditor.cpp
@@ -177,6 +177,8 @@ namespace LevelEditor
 	static TextureGpu* s_boolToolbarData = nullptr;
 	static TextureGpu* s_levelNoteIcon = nullptr;
 
+
+
 	////////////////////////////////////////////////////////
 	// Forward Declarations
 	////////////////////////////////////////////////////////
@@ -489,6 +491,150 @@ namespace LevelEditor
 			else if (s_editMode == LEDIT_ENTITY)
 			{
 				entityComputeDragSelect();
+			}
+		}
+	}
+
+	s32 getNextAvailableSectorReverse(s32 sectorId, std::vector<s32>& deletedIds)
+	{
+		bool found = false;
+		for (s32 i = sectorId - 1; i >= 0; i--)
+		{
+			found = true;
+			for (s32 j = 0; j < deletedIds.size(); j++)
+			{
+				if (deletedIds[j] == i)
+				{
+					found = false;
+					break;
+				}
+			}
+
+			if (found == true)
+			{
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	// Find all instances of wall adjoinId = x and replace with y.
+	void edit_remapAdjoinIds(std::vector<IndexPair>& adjoinRefs)
+	{
+		size_t sectorCount = s_level.sectors.size();
+		size_t adjoinRefCount = adjoinRefs.size();
+		if (sectorCount > 0 && adjoinRefCount > 0)
+		{
+			EditorSector* sector = s_level.sectors.data();
+			for (s32 s = 0; s < sectorCount; s++, sector++)
+			{
+				const s32 wallCount = (s32)sector->walls.size();
+				EditorWall* wall = sector->walls.data();
+				for (s32 w = 0; w < wallCount; w++, wall++)
+				{
+					for (s32 i = 0; i < adjoinRefs.size(); i++)
+					{
+						if (wall->adjoinId == adjoinRefs[i].i0)
+						{
+							wall->adjoinId = adjoinRefs[i].i1;
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Patch gaps in sector data with valid sectors from the end of the vec,
+	// then resize the vec as needed. This method should be kinder on the 
+	// history system as we arent re-iding everything
+	// 
+	// Note: ensure no adjoins point to the deleted sectors prior to
+	// calling this function. Those ids are getting reused!
+	void edit_insertValidSectorsFromEnd(std::vector<s32>& deletedSectorIds)
+	{
+		// Associations of deleted ids with good sector ids its patched over with for repairing adjoins later.
+		// i0 = original id of sector at end of vec which was re-id'd
+		// i1 = the id assigned
+		std::vector<IndexPair> sectorRefs;
+		s32 delSectorCount = (s32)deletedSectorIds.size();
+		s32 availableSectorId = (s32)s_level.sectors.size();
+
+		for (s32 i = 0; i < delSectorCount; i++)
+		{
+			// Get next available sectorId (ie not in the deleted Id vec).
+			availableSectorId = getNextAvailableSectorReverse(availableSectorId, deletedSectorIds);
+			if (availableSectorId < 0)
+			{
+				// No more available sectors.
+				break;
+			}
+			else if (availableSectorId < deletedSectorIds[i])
+			{
+				// Enough deleted ids have been swapped out that no more gaps need plugging
+				break;
+			}
+
+			// swap and update id to maintain id == vec[index] parity
+			sectorRefs.push_back({ availableSectorId, deletedSectorIds[i] });
+			std::swap(s_level.sectors[deletedSectorIds[i]], s_level.sectors[availableSectorId]);
+			s_level.sectors[deletedSectorIds[i]].id = deletedSectorIds[i];
+		}
+		s_level.sectors.resize((s32)s_level.sectors.size() - delSectorCount);
+
+		// Finally fix-up any references due to the prior swapping
+		edit_remapAdjoinIds(sectorRefs);
+	}
+
+	void edit_deleteSectors(std::vector<s32>& sectorIds, bool addToHistory)
+	{
+		std::sort(sectorIds.begin(), sectorIds.end()); // ids need to be sorted. mixing drag select & ctrl clicking wont be ordered.
+
+		std::vector<EditorSector> sectorSnapshot;
+		s32 delSectorCount = (s32)sectorIds.size();
+		size_t prevSectorCount = s_level.sectors.size();
+		if (addToHistory)
+		{
+			level_createLevelSectorSnapshotSameAssets(sectorSnapshot);
+		}
+
+		// First, go through all sectors and remove references.
+		s32 sectorCount = (s32)s_level.sectors.size();
+		EditorSector* sector = s_level.sectors.data();
+		for (s32 s = 0; s < sectorCount; s++, sector++)
+		{
+			if (std::find(sectorIds.begin(), sectorIds.end(), sector->id) != sectorIds.end())
+			{
+				continue;
+			}
+
+			const s32 wallCount = (s32)sector->walls.size();
+			EditorWall* wall = sector->walls.data();
+			for (s32 w = 0; w < wallCount; w++, wall++)
+			{
+				if (std::find(sectorIds.begin(), sectorIds.end(), wall->adjoinId) != sectorIds.end())
+				{
+					wall->adjoinId = -1;
+					wall->mirrorId = -1;
+				}
+			}
+		}
+
+		// Now no adjoins point to deleted sector ids. Plug those weak-deleted sectors with active
+		// sector data from the back of the sector vec.
+		edit_insertValidSectorsFromEnd(sectorIds);
+
+		// Selections are potentially invalid so clear.
+		edit_clearSelections(false);
+
+		// Handle history.
+		if (addToHistory)
+		{
+			std::vector<s32> deltaSectors;
+			level_getLevelSnapshotDelta(deltaSectors, sectorSnapshot);
+			if (!deltaSectors.empty() || prevSectorCount != s_level.sectors.size())
+			{
+				cmd_sectorSnapshot(LName_DeleteSector, deltaSectors);
 			}
 		}
 	}
@@ -854,6 +1000,21 @@ namespace LevelEditor
 				changedSet.push_back(indices[s]);
 			}
 
+			// Get all wall INFs for this sector
+			s_infWallTrack.clear();
+			
+			std::vector<Editor_InfItem*> infItems = editor_listInfItemsByName(sector->name);
+			if (!sector->name.empty())
+			{
+				for (const Editor_InfItem* item : infItems)
+				{
+					if (item->wallNum >= 0)
+					{
+						s_infWallTrack.push_back({ sector->name, item->wallNum, -1 });
+					}
+				}
+			}
+
 			// 1. Record all of the walls we are keeping.
 			std::vector<EditorWallRaw> wallsToKeep;
 			{
@@ -876,6 +1037,17 @@ namespace LevelEditor
 							{
 								next->walls[wall->mirrorId].adjoinId = -1;
 								next->walls[wall->mirrorId].mirrorId = -1;
+							}
+						}
+					}
+					else
+					{
+						// Wall added, test if INF'd. The most recent wall added is the new Id
+						for (size_t trackId = 0; trackId < s_infWallTrack.size(); trackId++)
+						{
+							if (s_infWallTrack[trackId].oldWall == w)
+							{
+								s_infWallTrack[trackId].newWall = (s32)(wallsToKeep.size() - 1);
 							}
 						}
 					}
@@ -973,6 +1145,29 @@ namespace LevelEditor
 					}
 				}
 			}
+
+			// 3. Update INF wall refs
+			INFWallTrack* wt = s_infWallTrack.data();
+			for (size_t i = 0; i < s_infWallTrack.size(); i++, wt++)
+			{
+				if (wt->newWall >= 0)
+				{
+					for (size_t infIndex = 0; infIndex < infItems.size(); infIndex++)
+					{
+						if (infItems[infIndex]->wallNum == wt->oldWall)
+						{
+							infItems[infIndex]->wallNum = wt->newWall;
+							break;
+						}
+					}
+				}
+				else
+				{
+					// No new wall id, lost in the reshuffle
+					LE_WARNING("INF target lost. Name: %s Id: %d", wt->name.c_str(), wt->oldWall);
+				}
+			}
+
 			sectorToPolygon(sector);
 		}
 		if (addToHistory)

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditor.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditor.cpp
@@ -2502,10 +2502,12 @@ namespace LevelEditor
 	{
 		if (isShortcutPressed(SHORTCUT_UNDO))
 		{
+			if (isPopupOpen()) return; // Avoid problems with INF UI
 			levHistory_undo();
 		}
 		else if (isShortcutPressed(SHORTCUT_REDO))
 		{
+			if (isPopupOpen()) return; // Avoid problems with INF UI
 			levHistory_redo();
 		}
 		if (isShortcutPressed(SHORTCUT_SHOW_ALL_LABELS))

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditor.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditor.h
@@ -85,6 +85,7 @@ namespace LevelEditor
 	// Shared Edit Commands
 	void edit_moveSelectedFlats(f32 delta);
 	bool edit_splitWall(s32 sectorId, s32 wallIndex, Vec2f newPos);
+	void edit_deleteSectors(std::vector<s32>& sectorIds, bool addToHistory = true);
 	void edit_deleteSector(s32 sectorId, bool addToHistory = true);
 	bool edit_tryAdjoin(s32 sectorId, s32 wallId, bool exactMatch = false);
 	void edit_removeAdjoin(s32 sectorId, s32 wallId);

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -98,6 +98,7 @@ namespace LevelEditor
 
 	static s32 s_curSnapshotId = -1;
 	static EditorLevel s_curSnapshot;
+	static Editor_LevelInf s_infSnapshot;
 
 	EditorLevel s_level = {};
 
@@ -5098,7 +5099,158 @@ namespace LevelEditor
 			sector->ceilTex = attrib.ceilTex;
 		}
 	}
-		
+
+	void clearInfData(Editor_LevelInf* levelInf)
+	{
+		for (size_t i = 0; i < levelInf->elevator.size(); i++)
+		{
+			delete levelInf->elevator[i];
+		}
+
+		for (size_t i = 0; i < levelInf->trigger.size(); i++)
+		{
+			delete levelInf->trigger[i];
+		}
+
+		for (size_t i = 0; i < levelInf->teleport.size(); i++)
+		{
+			delete levelInf->teleport[i];
+		}
+
+		levelInf->item.clear();
+		levelInf->elevator.clear();
+		levelInf->trigger.clear();
+		levelInf->teleport.clear();
+	}
+
+	// Reimplemention of getClassIndex() for the snapshot
+	s32 getClassIndexSnapshot(Editor_InfItemClass classId, const void* classPtr)
+	{
+		s32 index = -1;
+		if (classId == IIC_ELEVATOR)
+		{
+			const s32 count = (s32)s_infSnapshot.elevator.size();
+			const Editor_InfElevator* const* list = s_infSnapshot.elevator.data();
+			for (s32 i = 0; i < count; i++)
+			{
+				if (classPtr == list[i])
+				{
+					index = i;
+					break;
+				}
+			}
+		}
+		else if (classId == IIC_TRIGGER)
+		{
+			const s32 count = (s32)s_infSnapshot.trigger.size();
+			const Editor_InfTrigger* const* list = s_infSnapshot.trigger.data();
+			for (s32 i = 0; i < count; i++)
+			{
+				if (classPtr == list[i])
+				{
+					index = i;
+					break;
+				}
+			}
+		}
+		else if (classId == IIC_TELEPORTER)
+		{
+			const s32 count = (s32)s_infSnapshot.teleport.size();
+			const Editor_InfTeleporter* const* list = s_infSnapshot.teleport.data();
+			for (s32 i = 0; i < count; i++)
+			{
+				if (classPtr == list[i])
+				{
+					index = i;
+					break;
+				}
+			}
+		}
+		assert(index >= 0);
+		return index;
+	}
+
+	void copyInfData(Editor_LevelInf* infFrom, Editor_LevelInf* infTo)
+	{
+		clearInfData(infTo);
+
+		size_t elevCount = infFrom->elevator.size();
+		infTo->elevator.resize(elevCount);
+		Editor_InfElevator* elevFrom;
+		Editor_InfElevator* elevTo;
+		for (size_t i = 0; i < elevCount; i++)
+		{
+			// Create new object, assign the pointer then copy struct data
+			elevFrom = infFrom->elevator[i];
+			elevTo = new Editor_InfElevator();
+			infTo->elevator[i] = elevTo;
+			*elevTo = *elevFrom; // Copy the struct, not the pointer
+		}
+
+		size_t trigCount = infFrom->trigger.size();
+		infTo->trigger.resize(trigCount);
+		Editor_InfTrigger* trigFrom;
+		Editor_InfTrigger* trigTo;
+		for (size_t i = 0; i < trigCount; i++)
+		{
+			trigFrom = infFrom->trigger[i];
+			trigTo = new Editor_InfTrigger();
+			infTo->trigger[i] = trigTo;
+			*trigTo = *trigFrom;
+		}
+
+		size_t teleCount = infFrom->teleport.size();
+		infTo->teleport.resize(teleCount);
+		Editor_InfTeleporter* teleFrom;
+		Editor_InfTeleporter* teleTo;
+		for (size_t i = 0; i < teleCount; i++)
+		{
+			teleFrom = infFrom->teleport[i];
+			teleTo = new Editor_InfTeleporter();
+			infTo->teleport[i] = teleTo;
+			*teleTo = *teleFrom;
+		}
+
+		// If everything went correctly, the calculated indexes should be 
+		// the same for both source and destination
+		size_t itemCount = infFrom->item.size();
+		infTo->item.resize(itemCount);
+		for (size_t i = 0; i < itemCount; i++)
+		{
+			Editor_InfItem* itemTo = &infTo->item[i];
+			Editor_InfItem* itemFrom = &infFrom->item[i];			
+			itemTo->name = itemFrom->name;
+			itemTo->wallNum = itemFrom->wallNum;
+
+			size_t classCount = itemFrom->classData.size();
+			itemTo->classData.resize(classCount);
+			for (size_t j = 0; j < classCount; j++)
+			{
+				Editor_InfClass* infClass = itemFrom->classData[j];
+				Editor_InfItemClass classId = infClass->classId;
+				if (classId == IIC_ELEVATOR)
+				{
+					s32 index = getClassIndexSnapshot(classId, infClass);
+					itemTo->classData[j] = (Editor_InfClass*)infTo->elevator[index];
+				}
+				else if (classId == IIC_TRIGGER)
+				{
+					s32 index = getClassIndexSnapshot(classId, infClass);
+					itemTo->classData[j] = (Editor_InfClass*)infTo->trigger[index];
+				}
+				else if (classId == IIC_TELEPORTER)
+				{
+					s32 index = getClassIndexSnapshot(classId, infClass);
+					itemTo->classData[j] = (Editor_InfClass*)infTo->teleport[index];
+				}
+				else
+				{
+					assert(0);
+				}
+			}
+		}
+	}
+
 	void level_createSnapshot(SnapshotBuffer* buffer)
 	{
 		assert(buffer);
@@ -5121,6 +5273,7 @@ namespace LevelEditor
 		const u32 entityCount = (u32)s_level.entities.size();
 		const u32 levelNoteCount = (s32)s_level.notes.size();
 		const u32 guidelineCount = (s32)s_level.guidelines.size();
+
 		writeU32(texCount);
 		writeU32(sectorCount);
 		writeU32(entityCount);
@@ -5160,6 +5313,44 @@ namespace LevelEditor
 		for (u32 g = 0; g < guidelineCount; g++, guideline++)
 		{
 			writeGuidelineToSnapshot(guideline);
+		}
+
+		// Inf data.
+		const u32 infElevatorCount = (s32)s_levelInf.elevator.size();
+		const u32 infTriggerCount = (s32)s_levelInf.trigger.size();
+		const u32 infTeleporterCount = (s32)s_levelInf.teleport.size();
+		const u32 infItemCount = (s32)s_levelInf.item.size();
+		writeU32(infElevatorCount);
+		writeU32(infTriggerCount);
+		writeU32(infTeleporterCount);
+		writeU32(infItemCount);
+
+		// Inf Elevators
+		Editor_InfElevator** infElevator = s_levelInf.elevator.data();
+		for (u32 i = 0; i < infElevatorCount; i++, infElevator++)
+		{
+			writeInfElevatorToSnapshot(*infElevator);
+		}
+
+		// Inf Triggers
+		Editor_InfTrigger** infTrigger = s_levelInf.trigger.data();
+		for (u32 i = 0; i < infTriggerCount; i++, infTrigger++)
+		{
+			writeInfTriggerToSnapshot(*infTrigger);
+		}
+
+		// Inf Teleporters
+		Editor_InfTeleporter** infTeleporter = s_levelInf.teleport.data();
+		for (u32 i = 0; i < infTeleporterCount; i++, infTeleporter++)
+		{
+			writeInfTeleporterToSnapshot(*infTeleporter);
+		}
+
+		// Inf Items
+		const Editor_InfItem* infItem = s_levelInf.item.data();
+		for (u32 i = 0; i < infItemCount; i++, infItem++)
+		{
+			writeInfItemToSnapshot(infItem);
 		}
 	}
 
@@ -5237,9 +5428,80 @@ namespace LevelEditor
 			{
 				readGuidelineFromSnapshot(guideline);
 			}
+
+			// Restore Inf data
+			clearInfData(&s_infSnapshot);
+
+			const u32 infElevatorCount = readU32();
+			const u32 infTriggerCount = readU32();
+			const u32 infTeleporterCount = readU32();
+			const u32 infItemCount = readU32();
+
+			// Don't use existing alloc functions as those are tied to s_levelInf.
+			// elevators
+			for (u32 i = 0; i < infElevatorCount; i++)
+			{
+				Editor_InfElevator* elev = new Editor_InfElevator();
+				s_infSnapshot.elevator.push_back(elev);
+				elev->classId = IIC_ELEVATOR;
+				readInfElevatorFromSnapshot(elev);
+			}
+
+			// triggers
+			for (u32 i = 0; i < infTriggerCount; i++)
+			{
+				Editor_InfTrigger* trig = new Editor_InfTrigger();
+				s_infSnapshot.trigger.push_back(trig);
+				trig->classId = IIC_TRIGGER;
+				readInfTriggerFromSnapshot(trig);
+			}
+
+			// teleporters
+			for (u32 i = 0; i < infTeleporterCount; i++)
+			{
+				Editor_InfTeleporter* tele = new Editor_InfTeleporter();
+				s_infSnapshot.teleport.push_back(tele);
+				tele->classId = IIC_TELEPORTER;
+				readInfTeleporterFromSnapshot(tele);
+			}
+
+			// items
+			for (u32 i = 0; i < infItemCount; i++)
+			{
+				Editor_InfItem item;
+				readInfItemFromSnapshot(&item);
+				
+				// the rest of the classData are stored as indexes in the snapshot data.
+				// these need conversion to the memory address, recast as an Editor_InfClass*.
+				for (size_t i = 0; i < item.classData.size(); i++)
+				{
+					Editor_InfItemClass itemClass = (Editor_InfItemClass)readU32();
+					s32 itemIndex = readS32();
+					if (itemClass == IIC_ELEVATOR)
+					{
+						assert((s32)s_infSnapshot.elevator.size() > itemIndex);
+						item.classData[i] = ((Editor_InfClass*)s_infSnapshot.elevator[itemIndex]);
+					}
+					else if (itemClass == IIC_TRIGGER)
+					{
+						assert((s32)s_infSnapshot.trigger.size() > itemIndex);
+						item.classData[i] = ((Editor_InfClass*)s_infSnapshot.trigger[itemIndex]);
+					}
+					else if (itemClass == IIC_TELEPORTER)
+					{
+						assert((s32)s_infSnapshot.teleport.size() > itemIndex);
+						item.classData[i] = ((Editor_InfClass*)s_infSnapshot.teleport[itemIndex]);
+					}
+				}
+				s_infSnapshot.item.push_back(item);
+			}
 		}
+
 		// Then copy the snapshot to the level data itself. Its the new state.
 		s_level = s_curSnapshot;
+
+		// Repopulate the Inf struct
+		copyInfData(&s_infSnapshot, &s_levelInf);
 
 		// For now until the way snapshot memory is handled is refactored, to avoid duplicate code that will be removed later.
 		// TODO: Handle edit state properly here too.

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -508,10 +508,7 @@ namespace LevelEditor
 	void levelClear()
 	{
 		// Clear the INF data.
-		s_levelInf.item.clear();
-		s_levelInf.elevator.clear();
-		s_levelInf.teleport.clear();
-		s_levelInf.trigger.clear();
+		editor_infDestroy();
 
 		// Clear selection state.
 		selection_clear();
@@ -530,10 +527,7 @@ namespace LevelEditor
 		FileUtil::stripExtension(asset->name.c_str(), slotName);
 
 		// Clear the INF data.
-		s_levelInf.item.clear();
-		s_levelInf.elevator.clear();
-		s_levelInf.teleport.clear();
-		s_levelInf.trigger.clear();
+		editor_infDestroy();
 
 		// Clear selection state.
 		selection_clear();

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -5586,6 +5586,204 @@ namespace LevelEditor
 		}
 	}
 
+	void level_createInfItemModifySnapshot(SnapshotBuffer* buffer, u32 itemIndex)
+	{
+		setSnapshotWriteBuffer(buffer);
+		
+		Editor_InfItem* infItem = &s_levelInf.item[itemIndex];
+		u32 classCount = (u32)infItem->classData.size();
+		writeU32(itemIndex);
+		writeU32(classCount);
+		s32 deletedSize = (s32)s_infModified.deleteIndexes.size();
+		s32 modifiedSize = (s32)s_infModified.modifiedIndexes.size();
+		s32 newSize = (s32)s_infModified.newIndexes.size();
+		writeS32(deletedSize);
+		writeS32(modifiedSize);
+		writeS32(newSize);
+		writeData(s_infModified.deleteIndexes.data(), deletedSize);
+		writeData(s_infModified.modifiedIndexes.data(), modifiedSize);
+		writeData(s_infModified.newIndexes.data(), newSize);
+
+		for (s32 i = 0; i < modifiedSize; i++)
+		{
+			Editor_InfClass* infClass = infItem->classData[s_infModified.modifiedIndexes[i]];
+			Editor_InfItemClass infItemClass = infClass->classId;
+			writeU32((u32)infItemClass);
+			if (infItemClass == IIC_ELEVATOR)
+			{
+				writeInfElevatorToSnapshot((Editor_InfElevator*)infClass);
+			}
+			else if (infItemClass == IIC_TRIGGER)
+			{
+				writeInfTriggerToSnapshot((Editor_InfTrigger*)infClass);
+			}
+			else if (infItemClass == IIC_TELEPORTER)
+			{
+				writeInfTeleporterToSnapshot((Editor_InfTeleporter*)infClass);
+			}
+		}
+
+		for (s32 i = 0; i < newSize; i++)
+		{
+			Editor_InfClass* infClass = infItem->classData[s_infModified.newIndexes[i]];
+			Editor_InfItemClass infItemClass = infClass->classId;
+			writeU32((u32)infItemClass);
+			if (infItemClass == IIC_ELEVATOR)
+			{
+				writeInfElevatorToSnapshot((Editor_InfElevator*)infClass);
+			}
+			else if (infItemClass == IIC_TRIGGER)
+			{
+				writeInfTriggerToSnapshot((Editor_InfTrigger*)infClass);
+			}
+			else if (infItemClass == IIC_TELEPORTER)
+			{
+				writeInfTeleporterToSnapshot((Editor_InfTeleporter*)infClass);
+			}
+		}
+	}
+
+	void level_unpackInfItemModifySnapshot(u32 size, void* data)
+	{
+		setSnapshotReadBuffer((u8*)data, size);
+
+		const u32 itemIndex = readU32();
+		assert(itemIndex < (u32)s_levelInf.item.size());
+		Editor_InfItem* infItem = &s_levelInf.item[itemIndex];
+		const u32 classCount = readU32();
+
+		const s32 deletedIndexCount = readS32(); // Existing item.classData indexes
+		const s32 modifiedIndexCount = readS32();
+		const s32 newIndexCount = readS32();
+
+		std::vector<s32> deletedIndexes;
+		std::vector<s32> modifiedIndexes;
+		std::vector<s32> newIndexes;
+		deletedIndexes.resize(deletedIndexCount);
+		modifiedIndexes.resize(modifiedIndexCount);
+		newIndexes.resize(newIndexCount);
+		
+		readData(deletedIndexes.data(), deletedIndexCount);
+		readData(modifiedIndexes.data(), modifiedIndexCount);
+		readData(newIndexes.data(), newIndexCount);
+
+		for (s32 i = 0; i < deletedIndexCount; i++) // Assumed to be reverse order
+		{
+			freeInfClass(infItem->classData[deletedIndexes[i]]);
+			for (s32 j = deletedIndexes[i]; j < infItem->classData.size() - 1; j++) // Delete and shuffle back
+			{
+				infItem->classData[j] = infItem->classData[j + 1];
+			}
+			infItem->classData.pop_back();
+		}
+
+		for (s32 i = 0; i < modifiedIndexCount; i++)
+		{
+			Editor_InfItemClass classId = (Editor_InfItemClass)readU32();
+			Editor_InfClass* modifiedClass = infItem->classData[modifiedIndexes[i]];
+			if (classId == IIC_ELEVATOR)
+			{
+				readInfElevatorFromSnapshot((Editor_InfElevator*)modifiedClass);
+			}
+			else if (classId == IIC_TRIGGER)
+			{
+				readInfTriggerFromSnapshot((Editor_InfTrigger*)modifiedClass);
+			}
+			else if (classId == IIC_TELEPORTER)
+			{
+				readInfTeleporterFromSnapshot((Editor_InfTeleporter*)modifiedClass);
+			}
+		}
+
+		for (s32 i = 0; i < newIndexCount; i++)
+		{
+			Editor_InfItemClass classId = (Editor_InfItemClass)readU32();
+			if (classId == IIC_ELEVATOR)
+			{
+				Editor_InfElevator* elev = allocElev(infItem);
+				readInfElevatorFromSnapshot(elev);
+			}
+			else if (classId == IIC_TRIGGER)
+			{
+				Editor_InfTrigger* trig = allocTrigger(infItem);
+				readInfTriggerFromSnapshot(trig);
+			}
+			else if (classId == IIC_TELEPORTER)
+			{
+				Editor_InfTeleporter* tele = allocTeleporter(infItem);
+				readInfTeleporterFromSnapshot(tele);
+			}
+		}
+	}
+
+	void level_createInfItemSnapshot(SnapshotBuffer* buffer)
+	{
+		setSnapshotWriteBuffer(buffer);
+		Editor_InfItem* newItem = &s_levelInf.item.back();
+		u32 classCount = (u32)newItem->classData.size();
+		writeString(newItem->name);
+		writeS32(newItem->wallNum);
+		writeU32(classCount);
+		for (u32 i = 0; i < classCount; i++)
+		{
+			Editor_InfClass* itemClass = newItem->classData[i];
+			if (itemClass->classId == IIC_ELEVATOR)
+			{
+				writeU32(IIC_ELEVATOR);
+				writeInfElevatorToSnapshot((Editor_InfElevator*)itemClass);
+			}
+			else if (itemClass->classId == IIC_TRIGGER)
+			{
+				writeU32(IIC_TRIGGER);
+				writeInfTriggerToSnapshot((Editor_InfTrigger*)itemClass);
+			}
+			else if (itemClass->classId == IIC_TELEPORTER)
+			{
+				writeU32(IIC_TELEPORTER);
+				writeInfTeleporterToSnapshot((Editor_InfTeleporter*)itemClass);
+			}
+		}
+	}
+
+	void level_unpackCreateInfSnapshot(u32 size, void* data)
+	{
+		setSnapshotReadBuffer((u8*)data, size);
+		s_levelInf.item.push_back({});
+		Editor_InfItem* infItem = &s_levelInf.item.back();
+		readString(infItem->name);
+		infItem->wallNum = readS32();
+		const u32 classCount = readU32();
+
+		for (u32 i = 0; i < classCount; i++)
+		{
+			Editor_InfItemClass itemClass = (Editor_InfItemClass)readU32();
+			if (itemClass == IIC_ELEVATOR)
+			{
+				Editor_InfElevator* infElevator = new Editor_InfElevator();
+				s_levelInf.elevator.push_back(infElevator);
+				infElevator->classId = IIC_ELEVATOR;
+				readInfElevatorFromSnapshot(infElevator);
+				infItem->classData.push_back((Editor_InfClass*)infElevator);
+			}
+			else if (itemClass == IIC_TRIGGER)
+			{
+				Editor_InfTrigger* infTrigger = new Editor_InfTrigger();
+				s_levelInf.trigger.push_back(infTrigger);
+				infTrigger->classId = IIC_TRIGGER;
+				readInfTriggerFromSnapshot(infTrigger);
+				infItem->classData.push_back((Editor_InfClass*)infTrigger);
+			}
+			else if (itemClass == IIC_TELEPORTER)
+			{
+				Editor_InfTeleporter* infTeleporter = new Editor_InfTeleporter();
+				s_levelInf.teleport.push_back(infTeleporter);
+				infTeleporter->classId = IIC_TELEPORTER;
+				readInfTeleporterFromSnapshot(infTeleporter);
+				infItem->classData.push_back((Editor_InfClass*)infTeleporter);
+			}
+		}
+	}
+
 	// Find a sector based on DF rules.
 	EditorSector* findSectorDf(const Vec3f pos)
 	{

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -4832,10 +4832,12 @@ namespace LevelEditor
 		const u32 texCount = (u32)s_uniqueTextures.size();
 		const u32 sectorCount = (u32)s_sectorSnapshot.size();
 		const u32 entityCount = (u32)s_uniqueEntities.size();
+		const u32 wallTrackCount = (u32)s_infWallTrack.size();
 		writeU32(newSectorCount);
 		writeU32(texCount);
 		writeU32(sectorCount);
 		writeU32(entityCount);
+		writeU32(wallTrackCount);
 
 		// Textures.
 		const UniqueTexture* texture = s_uniqueTextures.data();
@@ -4858,6 +4860,13 @@ namespace LevelEditor
 		{
 			writeSectorToSnapshot(sector);
 		}
+
+		// Write INF moves
+		const INFWallTrack* wallTrack = s_infWallTrack.data();
+		for (u32 i = 0; i < wallTrackCount; i++, wallTrack++)
+		{
+			writeINFWallTrackToSnapshot(wallTrack);
+		}
 	}
 
 	void level_unpackSectorSnapshot(u32 size, void* data)
@@ -4868,6 +4877,7 @@ namespace LevelEditor
 		const u32 texCount = readU32();         // Number of unique textures from sectors in snapshot.
 		const u32 sectorCount = readU32();      // Number of sectors *in* snapshot.
 		const u32 entityCount = readU32();      // Number of unique entities from sectors in snapshot.
+		const u32 wallTrackCount = readU32();   // Number of INF wall ID updates to make
 
 		// Resize to post-snapshot sector total.
 		s_level.sectors.resize(newSectorCount);
@@ -4938,6 +4948,14 @@ namespace LevelEditor
 			// Build the sector polygon for the editor.
 			sectorToPolygon(sector);
 			sector->searchKey = 0;
+		}
+
+		for (u32 wt = 0; wt < wallTrackCount; wt++)
+		{
+			INFWallTrack tmp;
+			readINFWallTrackFromSnapshot(&tmp);
+			Editor_InfItem* infItem = editor_getInfItem(tmp.name.c_str(), tmp.oldWall);
+			infItem->wallNum = tmp.newWall;
 		}
 	}
 

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -5606,9 +5606,9 @@ namespace LevelEditor
 		writeS32(deletedSize);
 		writeS32(modifiedSize);
 		writeS32(newSize);
-		writeData(s_infModified.deleteIndexes.data(), deletedSize);
-		writeData(s_infModified.modifiedIndexes.data(), modifiedSize);
-		writeData(s_infModified.newIndexes.data(), newSize);
+		writeData(s_infModified.deleteIndexes.data(), sizeof(s32) * deletedSize);
+		writeData(s_infModified.modifiedIndexes.data(), sizeof(s32) * modifiedSize);
+		writeData(s_infModified.newIndexes.data(), sizeof(s32) * newSize);
 
 		for (s32 i = 0; i < modifiedSize; i++)
 		{
@@ -5669,9 +5669,9 @@ namespace LevelEditor
 		modifiedIndexes.resize(modifiedIndexCount);
 		newIndexes.resize(newIndexCount);
 		
-		readData(deletedIndexes.data(), deletedIndexCount);
-		readData(modifiedIndexes.data(), modifiedIndexCount);
-		readData(newIndexes.data(), newIndexCount);
+		readData(deletedIndexes.data(), sizeof(s32) * deletedIndexCount);
+		readData(modifiedIndexes.data(), sizeof(s32) * modifiedIndexCount);
+		readData(newIndexes.data(), sizeof(s32) * newIndexCount);
 
 		for (s32 i = 0; i < deletedIndexCount; i++) // Assumed to be reverse order
 		{

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -5500,6 +5500,12 @@ namespace LevelEditor
 		// Then copy the snapshot to the level data itself. Its the new state.
 		s_level = s_curSnapshot;
 
+		// ACAC: test
+		//if (!compareLevelInfs(s_infSnapshot, s_levelInf))
+		//{
+		//	LE_WARNING("INF NO MATCH");
+		//}
+
 		// Repopulate the Inf struct
 		copyInfData(&s_infSnapshot, &s_levelInf);
 

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.h
@@ -338,6 +338,8 @@ namespace LevelEditor
 	void level_createGuidelineSnapshot(TFE_Editor::SnapshotBuffer* buffer);
 	void level_createLevelNoteSnapshot(TFE_Editor::SnapshotBuffer* buffer);
 	void level_createSingleGuidelineSnapshot(TFE_Editor::SnapshotBuffer* buffer, s32 index);
+	void level_createInfItemSnapshot(TFE_Editor::SnapshotBuffer* buffer);
+	void level_createInfItemModifySnapshot(TFE_Editor::SnapshotBuffer* buffer, u32 itemIndex);
 
 	void level_createLevelSectorSnapshotSameAssets(std::vector<EditorSector>& sectors);
 	void level_getLevelSnapshotDelta(std::vector<s32>& modifiedSectors, const std::vector<EditorSector>& sectorSnapshot);
@@ -351,6 +353,8 @@ namespace LevelEditor
 	void level_unpackGuidelineSnapshot(u32 size, void* data);
 	void level_unpackSingleGuidelineSnapshot(u32 size, void* data);
 	void level_unpackLevelNoteSnapshot(u32 size, void* data);
+	void level_unpackCreateInfSnapshot(u32 size, void* data);
+	void level_unpackInfItemModifySnapshot(u32 size, void* data);
 	
 	// Spatial Queries
 	s32  findSectorByName(const char* name, s32 excludeId = -1);

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.cpp
@@ -30,6 +30,9 @@ namespace LevelEditor
 		LCmd_Guideline_Snapshot,
 		LCmd_Guideline_Snapshot_Single,
 		LCmd_LevelNote_Snapshot,
+		LCmd_Inf_Create_Snapshot,
+		LCmd_Inf_Modify_Snapshot,
+		//LCmd_Inf_Delete_Snapshot,
 		LCmd_Count
 	};
 
@@ -48,6 +51,8 @@ namespace LevelEditor
 	void cmd_applyGuidelineSnapshot();
 	void cmd_applyGuidelineSingleSnapshot();
 	void cmd_applyLevelNoteSnapshot();
+	void cmd_applyInfCreateSnapshot();
+	void cmd_applyInfModifySnapshot();
 
 	///////////////////////////////////
 	// API
@@ -64,6 +69,8 @@ namespace LevelEditor
 		history_registerCommand(LCmd_Guideline_Snapshot, cmd_applyGuidelineSnapshot);
 		history_registerCommand(LCmd_Guideline_Snapshot_Single, cmd_applyGuidelineSingleSnapshot);
 		history_registerCommand(LCmd_LevelNote_Snapshot, cmd_applyLevelNoteSnapshot);
+		history_registerCommand(LCmd_Inf_Create_Snapshot, cmd_applyInfCreateSnapshot);
+		history_registerCommand(LCmd_Inf_Modify_Snapshot, cmd_applyInfModifySnapshot);
 
 		history_registerName(LName_MoveVertex, "Move Vertice(s)");
 		history_registerName(LName_SetVertex, "Set Vertex Position");
@@ -107,6 +114,9 @@ namespace LevelEditor
 		history_registerName(LName_LevelNote_Delete, "Delete Note");
 		history_registerName(LName_LevelNote_Move, "Move Note");
 		history_registerName(LName_LevelNote_Change, "Change Note");
+		history_registerName(LName_Inf_Create, "Create INF Item");
+		history_registerName(LName_Inf_Change, "Edit INF Item");
+		history_registerName(LName_Inf_Delete, "Delete INF Item");
 	}
 
 	void levHistory_destroy()
@@ -347,6 +357,47 @@ namespace LevelEditor
 		}
 		CMD_END();
 	}
+
+	void cmd_infCreateSnapshot(u32 name)
+	{
+		s_workBuffer[0].clear();
+		s_workBuffer[1].clear();
+		level_createInfItemSnapshot(&s_workBuffer[0]);
+		if (s_workBuffer[0].empty()) { return; }
+
+		const u32 uncompressedSize = (u32)s_workBuffer[0].size();
+		const u32 compressedSize = compressBuffer();
+		if (!compressedSize) { return; }
+
+		CMD_BEGIN(LCmd_Inf_Create_Snapshot, name);
+		{
+			hBuffer_addU32(uncompressedSize);
+			hBuffer_addU32(compressedSize);
+			hBuffer_addArrayU8(compressedSize, s_workBuffer[1].data());
+		}
+		CMD_END();
+
+	}
+
+	void cmd_infModifySnapshot(u32 name, s32 index)
+	{
+		s_workBuffer[0].clear();
+		s_workBuffer[1].clear();
+		level_createInfItemModifySnapshot(&s_workBuffer[0], index);
+		if (s_workBuffer[0].empty()) { return; }
+
+		const u32 uncompressedSize = (u32)s_workBuffer[0].size();
+		const u32 compressedSize = compressBuffer();
+		if (!compressedSize) { return; }
+
+		CMD_BEGIN(LCmd_Inf_Modify_Snapshot, name);
+		{
+			hBuffer_addU32(uncompressedSize);
+			hBuffer_addU32(compressedSize);
+			hBuffer_addArrayU8(compressedSize, s_workBuffer[1].data());
+		}
+		CMD_END();
+	}
 		
 	////////////////////////////////
 	// History Commands
@@ -452,6 +503,32 @@ namespace LevelEditor
 		if (zstd_decompress(s_workBuffer[0].data(), uncompressedSize, compressedData, compressedSize))
 		{
 			level_unpackLevelNoteSnapshot(uncompressedSize, s_workBuffer[0].data());
+		}
+	}
+
+	void cmd_applyInfCreateSnapshot()
+	{
+		const u32 uncompressedSize = hBuffer_getU32();
+		const u32 compressedSize = hBuffer_getU32();
+		const u8* compressedData = hBuffer_getArrayU8(compressedSize);
+
+		s_workBuffer[0].resize(uncompressedSize);
+		if (zstd_decompress(s_workBuffer[0].data(), uncompressedSize, compressedData, compressedSize))
+		{
+			level_unpackCreateInfSnapshot(uncompressedSize, s_workBuffer[0].data());
+		}
+	}
+
+	void cmd_applyInfModifySnapshot()
+	{
+		const u32 uncompressedSize = hBuffer_getU32();
+		const u32 compressedSize = hBuffer_getU32();
+		const u8* compressedData = hBuffer_getArrayU8(compressedSize);
+
+		s_workBuffer[0].resize(uncompressedSize);
+		if (zstd_decompress(s_workBuffer[0].data(), uncompressedSize, compressedData, compressedSize))
+		{
+			level_unpackInfItemModifySnapshot(uncompressedSize, s_workBuffer[0].data());
 		}
 	}
 

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.h
@@ -50,6 +50,9 @@ namespace LevelEditor
 		LName_LevelNote_Delete,
 		LName_LevelNote_Move,
 		LName_LevelNote_Change,
+		LName_Inf_Create,
+		LName_Inf_Change,
+		LName_Inf_Delete,
 		LName_Count
 	};
 
@@ -71,4 +74,7 @@ namespace LevelEditor
 	void cmd_guidelineSnapshot(u32 name);
 	void cmd_levelNoteSnapshot(u32 name, bool idChanged);
 	void cmd_guidelineSingleSnapshot(u32 name, s32 index, bool idChanged);
+	void cmd_infCreateSnapshot(u32 name);
+	void cmd_infModifySnapshot(u32 name, s32 itemIndex);
+	// void cmd_infDeleteSnapshot(u32 name, u32 itemIndex);
 }

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -244,7 +244,6 @@ namespace LevelEditor
 		ITRIGGER_SINGLE
 	};
 
-	//static Editor_LevelInf s_levelInfTemp = {}; // Copy of state prior to editing
 	static Editor_InfItemHistory s_infItemTemp = {};
 	static InfEditor s_infEditor = {};
 	static InfEditorState s_infEditorState;
@@ -258,6 +257,8 @@ namespace LevelEditor
 	static std::vector<f32> s_relTime;
 	static std::vector<f32> s_stopValue;
 	static std::vector<EditorSector*> s_sectorsToFixup;
+
+	bool s_writeLog = false;
 
 	void editor_selectViewportFeature(Editor_InfClass* editClass, SelectMode mode, SelectionType type, s32 index0 = -1, s32 index1 = -1);
 	void modifySectorGeometry(Editor_InfItem* item = nullptr, EditorSector* sector = nullptr, Editor_InfElevator* elev = nullptr, s32 stopIndex = -1);
@@ -583,7 +584,7 @@ namespace LevelEditor
 		if (lElev->slaves.size() != rElev->slaves.size() ||
 			lElev->stops.size() != rElev->stops.size())
 		{
-			LE_WARNING("elev slave/stop count mismatch");
+			if (s_writeLog) LE_WARNING("elev slave/stop count mismatch");
 			return false;
 		}
 
@@ -601,7 +602,7 @@ namespace LevelEditor
 			lElev->eventMask != rElev->eventMask ||
 			lElev->entityMask != rElev->entityMask)
 		{
-			LE_WARNING("elevs don't match");
+			if (s_writeLog) LE_WARNING("elevs don't match");
 			return false;
 		}
 
@@ -610,7 +611,7 @@ namespace LevelEditor
 			if (lElev->slaves[j].name != rElev->slaves[j].name ||
 				lElev->slaves[j].angleOffset != rElev->slaves[j].angleOffset)
 			{
-				LE_WARNING("elev slave index %zu don't match", j);
+				if (s_writeLog) LE_WARNING("elev slave index %zu don't match", j);
 				return false;
 			}
 		}
@@ -624,7 +625,7 @@ namespace LevelEditor
 				lStop->msg.size() != rStop->msg.size() ||
 				lStop->scriptCall.size() != rStop->scriptCall.size())
 			{
-				LE_WARNING("elev stop index %zu cmd vecs dont match", j);
+				if (s_writeLog) LE_WARNING("elev stop index %zu cmd vecs dont match", j);
 				return false;
 			}
 
@@ -636,7 +637,7 @@ namespace LevelEditor
 				lStop->delay != rStop->delay ||
 				lStop->page != rStop->page)
 			{
-				LE_WARNING("elev stop index %zu data dont match", j);
+				if (s_writeLog) LE_WARNING("elev stop index %zu data dont match", j);
 				return false;
 			}
 
@@ -649,7 +650,7 @@ namespace LevelEditor
 					lAdj->wallIndex0 != rAdj->wallIndex0 ||
 					lAdj->wallIndex1 != rAdj->wallIndex1)
 				{
-					LE_WARNING("elev stop index %zu adj index %zu data dont match", j, k);
+					if (s_writeLog) LE_WARNING("elev stop index %zu adj index %zu data dont match", j, k);
 					return false;
 				}
 			}
@@ -661,7 +662,7 @@ namespace LevelEditor
 				if (lTex->donorSector != rTex->donorSector ||
 					lTex->fromCeiling != rTex->fromCeiling)
 				{
-					LE_WARNING("elev stop index %zu tex index %zu data dont match", j, k);
+					if (s_writeLog) LE_WARNING("elev stop index %zu tex index %zu data dont match", j, k);
 					return false;
 				}
 			}
@@ -676,7 +677,7 @@ namespace LevelEditor
 					lMsg->eventFlags != rMsg->eventFlags ||
 					(lMsg->arg[0] != rMsg->arg[0] || lMsg->arg[1] != rMsg->arg[1]))
 				{
-					LE_WARNING("elev index %zu stop index %zu msg index %zu data dont match", j, k);
+					if (s_writeLog) LE_WARNING("elev index %zu stop index %zu msg index %zu data dont match", j, k);
 					return false;
 				}
 			}
@@ -691,7 +692,7 @@ namespace LevelEditor
 					lCall->arg[2].value != rCall->arg[2].value ||
 					lCall->arg[3].value != rCall->arg[3].value)
 				{
-					LE_WARNING("elev stop index %zu script index %zu data dont match", j, k);
+					if (s_writeLog) LE_WARNING("elev stop index %zu script index %zu data dont match", j, k);
 					return false;
 				}
 			}
@@ -704,7 +705,7 @@ namespace LevelEditor
 	{
 		if (lTrig->clients.size() != rTrig->clients.size())
 		{
-			LE_WARNING("trig client size not match");
+			if (s_writeLog) LE_WARNING("trig client size not match");
 			return false;
 		}
 		if (lTrig->classId != rTrig->classId ||
@@ -719,7 +720,7 @@ namespace LevelEditor
 			lTrig->entityMask != rTrig->entityMask ||
 			lTrig->event != rTrig->event)
 		{
-			LE_WARNING("trig data not match");
+			if (s_writeLog) LE_WARNING("trig data not match");
 			return false;
 		}
 
@@ -731,7 +732,7 @@ namespace LevelEditor
 				lClient->targetWall != rClient->targetWall ||
 				lClient->eventMask != rClient->eventMask)
 			{
-				LE_WARNING("trig client index %zu data not match", j);
+				if (s_writeLog) LE_WARNING("trig client index %zu data not match", j);
 				return false;
 			}
 		}
@@ -747,7 +748,7 @@ namespace LevelEditor
 			(lTele->dstPos.x != rTele->dstPos.x || lTele->dstPos.y != rTele->dstPos.y || lTele->dstPos.z != rTele->dstPos.z) ||
 			lTele->dstAngle != rTele->dstAngle)
 		{
-			LE_WARNING("tele data not match");
+			if (s_writeLog) LE_WARNING("tele data not match");
 			return false;
 		}
 
@@ -783,7 +784,7 @@ namespace LevelEditor
 			left.trigger.size() != right.trigger.size() ||
 			left.teleport.size() != right.teleport.size())
 		{
-			LE_WARNING("compareLevelInfs(): vec sizes don't match");
+			if (s_writeLog) LE_WARNING("compareLevelInfs(): vec sizes don't match");
 			return false;
 		}
 
@@ -792,7 +793,7 @@ namespace LevelEditor
 			if ((left.item[i].name != right.item[i].name) ||
 				(left.item[i].wallNum != right.item[i].wallNum))
 			{
-				LE_WARNING("compareLevelInfs(): item index %zu don't match", i);
+				if (s_writeLog) LE_WARNING("compareLevelInfs(): item index %zu don't match", i);
 				return false;
 			}
 		}
@@ -804,7 +805,7 @@ namespace LevelEditor
 
 			if (!isInfElevatorEqual(lElev, rElev))
 			{
-				LE_WARNING("Elev index: %zu", i);
+				if (s_writeLog) LE_WARNING("Elev index: %zu", i);
 				return false;
 			}
 		}
@@ -816,7 +817,7 @@ namespace LevelEditor
 
 			if (!isInfTriggerEqual(lTrig, rTrig))
 			{
-				LE_WARNING("Trig index: %zu", i);
+				if (s_writeLog) LE_WARNING("Trig index: %zu", i);
 				return false;
 			}
 		}
@@ -828,7 +829,7 @@ namespace LevelEditor
 	
 			if (!isInfTeleporterEqual(lTele, rTele))
 			{
-				LE_WARNING("Tele index: %zu", i);
+				if (s_writeLog) LE_WARNING("Tele index: %zu", i);
 				return false;
 			}
 		}

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -248,6 +248,7 @@ namespace LevelEditor
 	static InfEditor s_infEditor = {};
 	static InfEditorState s_infEditorState;
 	InfModified s_infModified = {};
+	std::vector<INFWallTrack> s_infWallTrack;
 
 	static ImVec2 s_popupPos;
 	static s32 s_restorePos = 0;
@@ -1773,6 +1774,21 @@ namespace LevelEditor
 			}
 		}
 		return nullptr;
+	}
+
+	std::vector<Editor_InfItem*> editor_listInfItemsByName(std::string& sectorName)
+	{
+		std::vector<Editor_InfItem*> result;
+		const size_t itemCount = s_levelInf.item.size();
+		Editor_InfItem* item = s_levelInf.item.data();
+		for (size_t i = 0; i < itemCount; i++, item++)
+		{
+			if (sectorName == item->name)
+			{
+				result.push_back(item);
+			}
+		}
+		return result;
 	}
 		
 	void editor_infEditBegin(const char* sectorName, s32 wallIndex)

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -244,8 +244,11 @@ namespace LevelEditor
 		ITRIGGER_SINGLE
 	};
 
+	//static Editor_LevelInf s_levelInfTemp = {}; // Copy of state prior to editing
+	static Editor_InfItemHistory s_infItemTemp = {};
 	static InfEditor s_infEditor = {};
 	static InfEditorState s_infEditorState;
+	InfModified s_infModified = {};
 
 	static ImVec2 s_popupPos;
 	static s32 s_restorePos = 0;
@@ -380,6 +383,22 @@ namespace LevelEditor
 			s_levelInf.teleport[i] = s_levelInf.teleport[i + 1];
 		}
 		s_levelInf.teleport.pop_back();
+	}
+
+	void freeInfClass(Editor_InfClass* infClass)
+	{
+		if (infClass->classId == IIC_ELEVATOR)
+		{
+			freeElevator((Editor_InfElevator*)infClass);
+		}
+		else if (infClass->classId == IIC_TRIGGER)
+		{
+			freeTrigger((Editor_InfTrigger*)infClass);
+		}
+		else if (infClass->classId == IIC_TELEPORTER)
+		{
+			freeTeleporter((Editor_InfTeleporter*)infClass);
+		}
 	}
 		
 	Editor_InfElevator* getElevFromClassData(Editor_InfClass* data)
@@ -559,6 +578,203 @@ namespace LevelEditor
 		client->targetSector = arg;
 	}
 
+	bool isInfElevatorEqual(Editor_InfElevator* lElev, Editor_InfElevator* rElev)
+	{
+		if (lElev->slaves.size() != rElev->slaves.size() ||
+			lElev->stops.size() != rElev->stops.size())
+		{
+			LE_WARNING("elev slave/stop count mismatch");
+			return false;
+		}
+
+		if (lElev->classId != rElev->classId ||
+			lElev->type != rElev->type ||
+			lElev->overrideSet != rElev->overrideSet ||
+			lElev->start != rElev->start ||
+			lElev->speed != rElev->speed ||
+			lElev->angle != rElev->angle ||
+			lElev->flags != rElev->flags ||
+			(lElev->key[0] != rElev->key[0] || lElev->key[1] != rElev->key[1]) ||
+			(lElev->center.x != rElev->center.x || lElev->center.z != rElev->center.z) ||
+			(lElev->sounds[0] != rElev->sounds[0] || lElev->sounds[1] != rElev->sounds[1] || lElev->sounds[2] != rElev->sounds[2]) ||
+			lElev->master != rElev->master ||
+			lElev->eventMask != rElev->eventMask ||
+			lElev->entityMask != rElev->entityMask)
+		{
+			LE_WARNING("elevs don't match");
+			return false;
+		}
+
+		for (size_t j = 0; j < lElev->slaves.size(); j++)
+		{
+			if (lElev->slaves[j].name != rElev->slaves[j].name ||
+				lElev->slaves[j].angleOffset != rElev->slaves[j].angleOffset)
+			{
+				LE_WARNING("elev slave index %zu don't match", j);
+				return false;
+			}
+		}
+
+		for (size_t j = 0; j < lElev->stops.size(); j++)
+		{
+			Editor_InfStop* lStop = &lElev->stops[j];
+			Editor_InfStop* rStop = &rElev->stops[j];
+			if (lStop->adjoinCmd.size() != rStop->adjoinCmd.size() ||
+				lStop->textureCmd.size() != rStop->textureCmd.size() ||
+				lStop->msg.size() != rStop->msg.size() ||
+				lStop->scriptCall.size() != rStop->scriptCall.size())
+			{
+				LE_WARNING("elev stop index %zu cmd vecs dont match", j);
+				return false;
+			}
+
+			if (lStop->overrideSet != rStop->overrideSet ||
+				lStop->relative != rStop->relative ||
+				lStop->value != rStop->value ||
+				lStop->fromSectorFloor != rStop->fromSectorFloor ||
+				lStop->delayType != rStop->delayType ||
+				lStop->delay != rStop->delay ||
+				lStop->page != rStop->page)
+			{
+				LE_WARNING("elev stop index %zu data dont match", j);
+				return false;
+			}
+
+			for (size_t k = 0; k < lStop->adjoinCmd.size(); k++)
+			{
+				Editor_InfAdjoinCmd* lAdj = &lStop->adjoinCmd[k];
+				Editor_InfAdjoinCmd* rAdj = &rStop->adjoinCmd[k];
+				if (lAdj->sector0 != rAdj->sector0 ||
+					lAdj->sector1 != rAdj->sector1 ||
+					lAdj->wallIndex0 != rAdj->wallIndex0 ||
+					lAdj->wallIndex1 != rAdj->wallIndex1)
+				{
+					LE_WARNING("elev stop index %zu adj index %zu data dont match", j, k);
+					return false;
+				}
+			}
+
+			for (size_t k = 0; k < lStop->textureCmd.size(); k++)
+			{
+				Editor_InfTextureCmd* lTex = &lStop->textureCmd[k];
+				Editor_InfTextureCmd* rTex = &rStop->textureCmd[k];
+				if (lTex->donorSector != rTex->donorSector ||
+					lTex->fromCeiling != rTex->fromCeiling)
+				{
+					LE_WARNING("elev stop index %zu tex index %zu data dont match", j, k);
+					return false;
+				}
+			}
+
+			for (size_t k = 0; k < lStop->msg.size(); k++)
+			{
+				Editor_InfMessage* lMsg = &lStop->msg[k];
+				Editor_InfMessage* rMsg = &rStop->msg[k];
+				if (lMsg->targetSector != rMsg->targetSector ||
+					lMsg->targetWall != rMsg->targetWall ||
+					lMsg->type != rMsg->type ||
+					lMsg->eventFlags != rMsg->eventFlags ||
+					(lMsg->arg[0] != rMsg->arg[0] || lMsg->arg[1] != rMsg->arg[1]))
+				{
+					LE_WARNING("elev index %zu stop index %zu msg index %zu data dont match", j, k);
+					return false;
+				}
+			}
+
+			for (size_t k = 0; k < lStop->scriptCall.size(); k++)
+			{
+				Editor_ScriptCall* lCall = &lStop->scriptCall[k];
+				Editor_ScriptCall* rCall = &rStop->scriptCall[k];
+				if (lCall->funcName != rCall->funcName ||
+					lCall->arg[0].value != rCall->arg[0].value ||
+					lCall->arg[1].value != rCall->arg[1].value ||
+					lCall->arg[2].value != rCall->arg[2].value ||
+					lCall->arg[3].value != rCall->arg[3].value)
+				{
+					LE_WARNING("elev stop index %zu script index %zu data dont match", j, k);
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	bool isInfTriggerEqual(Editor_InfTrigger* lTrig, Editor_InfTrigger* rTrig)
+	{
+		if (lTrig->clients.size() != rTrig->clients.size())
+		{
+			LE_WARNING("trig client size not match");
+			return false;
+		}
+		if (lTrig->classId != rTrig->classId ||
+			lTrig->type != rTrig->type ||
+			lTrig->overrideSet != rTrig->overrideSet ||
+			lTrig->cmd != rTrig->cmd ||
+			(lTrig->arg[0] != rTrig->arg[0] || lTrig->arg[1] != rTrig->arg[1]) ||
+			lTrig->sound != rTrig->sound ||
+			lTrig->master != rTrig->master ||
+			lTrig->textId != rTrig->textId ||
+			lTrig->eventMask != rTrig->eventMask ||
+			lTrig->entityMask != rTrig->entityMask ||
+			lTrig->event != rTrig->event)
+		{
+			LE_WARNING("trig data not match");
+			return false;
+		}
+
+		for (size_t j = 0; j < lTrig->clients.size(); j++)
+		{
+			Editor_InfClient* lClient = &lTrig->clients[j];
+			Editor_InfClient* rClient = &rTrig->clients[j];
+			if (lClient->targetSector != rClient->targetSector ||
+				lClient->targetWall != rClient->targetWall ||
+				lClient->eventMask != rClient->eventMask)
+			{
+				LE_WARNING("trig client index %zu data not match", j);
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool isInfTeleporterEqual(Editor_InfTeleporter* lTele, Editor_InfTeleporter* rTele)
+	{
+		if (lTele->classId != rTele->classId ||
+			lTele->type != rTele->type ||
+			lTele->target != rTele->target ||
+			(lTele->dstPos.x != rTele->dstPos.x || lTele->dstPos.y != rTele->dstPos.y || lTele->dstPos.z != rTele->dstPos.z) ||
+			lTele->dstAngle != rTele->dstAngle)
+		{
+			LE_WARNING("tele data not match");
+			return false;
+		}
+
+		return true;
+	}
+
+	bool isInfClassEqual(Editor_InfClass* lClass, Editor_InfClass* rClass)
+	{
+		if (lClass->classId == rClass->classId)
+		{
+			if (lClass->classId == IIC_ELEVATOR)
+			{
+				return isInfElevatorEqual((Editor_InfElevator*)lClass, (Editor_InfElevator*)rClass);
+			}
+			else if (lClass->classId == IIC_TRIGGER)
+			{
+				return isInfTriggerEqual((Editor_InfTrigger*)lClass, (Editor_InfTrigger*)rClass);
+			}
+			else if (lClass->classId == IIC_TELEPORTER)
+			{
+				return isInfTeleporterEqual((Editor_InfTeleporter*)lClass, (Editor_InfTeleporter*)rClass);
+			}
+		}
+		assert(0); // Hard fail to catch mismatched class types. Something has gone wrong.
+		return false;
+	}
+
 	// Walk each member of two Editor_LevelInf structs testing for equality. Inf undo is scary.
 	bool compareLevelInfs(Editor_LevelInf& left, Editor_LevelInf& right)
 	{	
@@ -586,176 +802,33 @@ namespace LevelEditor
 			Editor_InfElevator* lElev = left.elevator[i];
 			Editor_InfElevator* rElev = right.elevator[i];
 
-			if (lElev->slaves.size() != rElev->slaves.size() ||
-				lElev->stops.size() != rElev->stops.size())
+			if (!isInfElevatorEqual(lElev, rElev))
 			{
-				LE_WARNING("compareLevelInfs(): elev index %zu slave/stop count mismatch", i);
+				LE_WARNING("Elev index: %zu", i);
 				return false;
 			}
-
-
-			if (lElev->classId != rElev->classId ||
-				lElev->type != rElev->type ||
-				lElev->overrideSet != rElev->overrideSet ||
-				lElev->start != rElev->start ||
-				lElev->speed != rElev->speed ||
-				lElev->angle != rElev->angle ||
-				lElev->flags != rElev->flags ||
-				(lElev->key[0] != rElev->key[0] || lElev->key[1] != rElev->key[1]) ||
-				(lElev->center.x != rElev->center.x || lElev->center.z != rElev->center.z) ||
-				(lElev->sounds[0] != rElev->sounds[0] || lElev->sounds[1] != rElev->sounds[1] || lElev->sounds[2] != rElev->sounds[2]) ||
-				lElev->master != rElev->master ||
-				lElev->eventMask != rElev->eventMask ||
-				lElev->entityMask != rElev->entityMask)
-			{
-				LE_WARNING("compareLevelInfs(): elev index %zu don't match", i);
-				return false;
-			}
-
-			for (size_t j = 0; j < lElev->slaves.size(); j++)
-			{
-				if (lElev->slaves[j].name != rElev->slaves[j].name ||
-					lElev->slaves[j].angleOffset != rElev->slaves[j].angleOffset)
-				{
-					LE_WARNING("compareLevelInfs(): elev index %zu slave index %zu don't match", i, j);
-					return false;
-				}
-			}
-
-			for (size_t j = 0; j < lElev->stops.size(); j++)
-			{
-				Editor_InfStop* lStop = &lElev->stops[j];
-				Editor_InfStop* rStop = &rElev->stops[j];
-				if (lStop->adjoinCmd.size() != rStop->adjoinCmd.size() ||
-					lStop->textureCmd.size() != rStop->textureCmd.size() ||
-					lStop->msg.size() != rStop->msg.size() ||
-					lStop->scriptCall.size() != rStop->scriptCall.size())
-				{
-					LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu cmd vecs dont match", i, j);
-					return false;
-				}
-				
-				if (lStop->overrideSet != rStop->overrideSet ||
-					lStop->relative != rStop->relative ||
-					lStop->value != rStop->value ||
-					lStop->fromSectorFloor != rStop->fromSectorFloor ||
-					lStop->delayType != rStop->delayType ||
-					lStop->delay != rStop->delay ||
-					lStop->page != rStop->page)
-				{
-					LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu data dont match", i, j);
-					return false;
-				}
-
-				for (size_t k = 0; k < lStop->adjoinCmd.size(); k++)
-				{
-					Editor_InfAdjoinCmd* lAdj = &lStop->adjoinCmd[k];
-					Editor_InfAdjoinCmd* rAdj = &rStop->adjoinCmd[k];
-					if (lAdj->sector0 != rAdj->sector0 ||
-						lAdj->sector1 != rAdj->sector1 ||
-						lAdj->wallIndex0 != rAdj->wallIndex0 ||
-						lAdj->wallIndex1 != rAdj->wallIndex1)
-					{
-						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu adj index %zu data dont match", i, j, k);
-						return false;
-					}
-				}
-
-				for (size_t k = 0; k < lStop->textureCmd.size(); k++)
-				{
-					Editor_InfTextureCmd* lTex = &lStop->textureCmd[k];
-					Editor_InfTextureCmd* rTex = &rStop->textureCmd[k];
-					if (lTex->donorSector != rTex->donorSector ||
-						lTex->fromCeiling != rTex->fromCeiling)
-					{
-						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu tex index %zu data dont match", i, j, k);
-						return false;
-					}
-				}
-
-				for (size_t k = 0; k < lStop->msg.size(); k++)
-				{
-					Editor_InfMessage* lMsg = &lStop->msg[k];
-					Editor_InfMessage* rMsg = &rStop->msg[k];
-					if (lMsg->targetSector != rMsg->targetSector ||
-						lMsg->targetWall != rMsg->targetWall ||
-						lMsg->type != rMsg->type ||
-						lMsg->eventFlags != rMsg->eventFlags ||
-						(lMsg->arg[0] != rMsg->arg[0] || lMsg->arg[1] != rMsg->arg[1]))
-					{
-						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu msg index %zu data dont match", i, j, k);
-						return false;
-					}
-				}
-
-				for (size_t k = 0; k < lStop->scriptCall.size(); k++)
-				{
-					Editor_ScriptCall* lCall = &lStop->scriptCall[k];
-					Editor_ScriptCall* rCall = &rStop->scriptCall[k];
-					if (lCall->funcName != rCall->funcName ||
-						lCall->arg[0].value != rCall->arg[0].value ||
-						lCall->arg[1].value != rCall->arg[1].value ||
-						lCall->arg[2].value != rCall->arg[2].value ||
-						lCall->arg[3].value != rCall->arg[3].value)
-					{
-						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu script index %zu data dont match", i, j, k);
-						return false;
-					}
-				}
-			} // for elev stops
-		} // for elev
+		}
 
 		for (size_t i = 0; i < left.trigger.size(); i++)
 		{
 			Editor_InfTrigger* lTrig = left.trigger[i];
 			Editor_InfTrigger* rTrig = right.trigger[i];
 
-			if (lTrig->clients.size() != rTrig->clients.size())
+			if (!isInfTriggerEqual(lTrig, rTrig))
 			{
-				LE_WARNING("compareLevelInfs(): trig index %zu client size not match", i);
+				LE_WARNING("Trig index: %zu", i);
 				return false;
 			}
-			if (lTrig->classId != rTrig->classId ||
-				lTrig->type != rTrig->type ||
-				lTrig->overrideSet != rTrig->overrideSet ||
-				lTrig->cmd != rTrig->cmd ||
-				(lTrig->arg[0] != rTrig->arg[0] || lTrig->arg[1] != rTrig->arg[1]) ||
-				lTrig->sound != rTrig->sound ||
-				lTrig->master != rTrig->master ||
-				lTrig->textId != rTrig->textId ||
-				lTrig->eventMask != rTrig->eventMask ||
-				lTrig->entityMask != rTrig->entityMask ||
-				lTrig->event != rTrig->event)
-			{
-				LE_WARNING("compareLevelInfs(): trig index %zu data not match", i);
-				return false;
-			}
-
-			for (size_t j = 0; j < lTrig->clients.size(); j++)
-			{
-				Editor_InfClient* lClient = &lTrig->clients[j];
-				Editor_InfClient* rClient = &rTrig->clients[j];
-				if (lClient->targetSector != rClient->targetSector ||
-					lClient->targetWall != rClient->targetWall ||
-					lClient->eventMask != rClient->eventMask)
-				{
-					LE_WARNING("compareLevelInfs(): trig index %zu client index %zu data not match", i, j);
-					return false;
-				}
-			}
-		} // for trig
+		}
 
 		for (size_t i = 0; i < left.teleport.size(); i++)
 		{
 			Editor_InfTeleporter* lTele = left.teleport[i];
 			Editor_InfTeleporter* rTele = right.teleport[i];
-			if (lTele->classId != rTele->classId ||
-				lTele->type != rTele->type ||
-				lTele->target != rTele->target ||
-				(lTele->dstPos.x != rTele->dstPos.x || lTele->dstPos.y != rTele->dstPos.y || lTele->dstPos.z != rTele->dstPos.z) ||
-				lTele->dstAngle != rTele->dstAngle)
+	
+			if (!isInfTeleporterEqual(lTele, rTele))
 			{
-				LE_WARNING("compareLevelInfs(): tele index %zu data not match", i);
+				LE_WARNING("Tele index: %zu", i);
 				return false;
 			}
 		}
@@ -1734,9 +1807,218 @@ namespace LevelEditor
 		}
 	}
 
+	bool isClassIndexesMatched()
+	{
+		for (const IndexPair pair : s_infModified.matches)
+		{
+			if (pair.i0 != pair.i1)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	void clearInfItemTemp()
+	{
+		for (s32 i = (s32)s_infItemTemp.classData.size() - 1; i >= 0; i--)
+		{
+			Editor_InfClass* itemClass = s_infItemTemp.classData[i];
+			if (itemClass->classId == IIC_ELEVATOR)
+			{
+				Editor_InfElevator* elev = (Editor_InfElevator*)itemClass;
+				delete elev;
+			}
+			else if (itemClass->classId == IIC_TRIGGER)
+			{
+				Editor_InfTrigger* trig = (Editor_InfTrigger*)itemClass;
+				delete trig;
+			}
+			else if (itemClass->classId == IIC_TELEPORTER)
+			{
+				Editor_InfTeleporter* tele = (Editor_InfTeleporter*)itemClass;
+				delete tele;
+			}
+		}
+		s_infItemTemp = {};
+	}
+
+	void setInfItemTemp(Editor_InfItem* infItem)
+	{
+		s_infItemTemp.name = s_infEditor.item->name;
+		s_infItemTemp.wallNum = s_infEditor.item->wallNum;
+
+		// doing another set of allocs to compare against later feels a bit silly
+		for (size_t i = 0; i < s_infEditor.item->classData.size(); i++)
+		{
+			Editor_InfClass* infClass = s_infEditor.item->classData[i];
+			s_infItemTemp.classPtr.push_back((void*)infClass);
+			if (infClass->classId == IIC_ELEVATOR)
+			{
+				Editor_InfElevator* elev = new Editor_InfElevator();
+				elev->classId = IIC_ELEVATOR;
+				s_infItemTemp.classData.push_back((Editor_InfClass*)elev);
+				*elev = *(Editor_InfElevator*)s_infEditor.item->classData[i];
+
+			}
+			else if (infClass->classId == IIC_TRIGGER)
+			{
+				Editor_InfTrigger* trig = new Editor_InfTrigger();
+				trig->classId = IIC_TRIGGER;
+				s_infItemTemp.classData.push_back((Editor_InfClass*)trig);
+				*trig = *(Editor_InfTrigger*)s_infEditor.item->classData[i];
+			}
+			else if (infClass->classId == IIC_TELEPORTER)
+			{
+				Editor_InfTeleporter* tele = new Editor_InfTeleporter();
+				tele->classId = IIC_TELEPORTER;
+				s_infItemTemp.classData.push_back((Editor_InfClass*)tele);
+				*tele = *(Editor_InfTeleporter*)s_infEditor.item->classData[i];
+			}
+		}
+	}
+
+	void findInfChangesForHistory()
+	{
+		// INF class definitions and each item's reference to it are behind heap allocated
+		// pointers. Fine while in memory but for serialisation we need indexes instead.
+		// For saving to TFL export that's easy just capture the order at point in time.
+		
+		// For history functions, we assume all changes are limited in scope
+		// to the Editor_InfItem that the UI is pointing to, and its classData[]. Within
+		// that scope, capture the changes. Actions within here will change the index of
+		// classData members around it, so being able to identify which classData before editing
+		// matches which classData after editing is essential. As there is, currently, no
+		// unique identifier within each INF class, the next best thing to match on 
+		// is the pointer address.
+
+		// We can't just clone the pointers into a new Editor_InfItem and compare later
+		// because those pointers will also point to the modified future state which doesn't
+		// work. This is why Editor_InfItemHistory was made, to take coipes the pointer addresses
+		// and save to classPtr[]. Then we can manually alloc copies of the original data
+		// and do deep comparisons to test for modifications later.
+
+		// FIXME: Possible bug if allocElev/Trig allocs the same address while in the UI?
+		// Maybe this is a good reason for a uniqueId/serial in the class itself?
+
+
+		if (s_infEditor.item == nullptr)
+		{
+			return; // FIXME: deletions?
+		}
+
+		void* classPtr = nullptr;
+		Editor_InfItem* infItem = s_levelInf.item.data();
+
+		std::vector<IndexPair> currentClasses;
+
+		s32 currentItemIndex = -1;
+		s32 index = 0;
+		
+		s_infModified.matches.clear();
+		s_infModified.deleteIndexes.clear();
+		s_infModified.modifiedIndexes.clear();
+		s_infModified.newIndexes.clear();
+		
+
+		if (s_infEditor.item != nullptr)
+		{
+			currentItemIndex = (s32)(s_infEditor.item - s_levelInf.item.data());
+			if (currentItemIndex >= s_infItemTemp.infCount)
+			{
+				// New item. Any class data is assumed new entries.
+				cmd_infCreateSnapshot(LName_Inf_Create);
+			}
+			else
+			{
+				// Modified item.
+				// 1. Test for deletions.
+				Editor_InfClass* beforeItemClass;
+				Editor_InfClass* afterItemClass;
+				void* beforeItemPtr;
+				void* afterItemPtr;
+
+				bool found = false;
+				s32 oldClassDataSize = (s32)s_infItemTemp.classData.size();
+				s32 newClassDataSize = (s32)s_levelInf.item[currentItemIndex].classData.size();
+				for (s32 oldClassIndex = oldClassDataSize - 1; oldClassIndex >= 0; oldClassIndex--) // Store in the vec in descending order
+				{
+					found = false;
+					beforeItemPtr = s_infItemTemp.classPtr[oldClassIndex];
+					for (s32 newClassIndex = 0; newClassIndex < newClassDataSize; newClassIndex++)
+					{
+						afterItemPtr = (void*)s_levelInf.item[currentItemIndex].classData[newClassIndex];
+						
+						// There is no unique identifier within each class. So the only way to find matching
+						// classes before and after, assuming the index can shuffle around, is by comparing 
+						// the pointer addresses.
+						if (beforeItemPtr == afterItemPtr) 
+						{
+							assert(oldClassIndex >= newClassIndex); // Deletions may demote order in classData, but should never be higher.
+							s_infModified.matches.push_back({ oldClassIndex, newClassIndex });
+							found = true;
+							break;
+						}
+					}
+					if (!found)
+					{
+						s_infModified.deleteIndexes.push_back(oldClassIndex);
+					}
+				}
+				
+				// 2. Test for equality of matches
+				for (s32 i = 0; i < s_infModified.matches.size(); i++)
+				{
+					beforeItemClass = s_infItemTemp.classData[s_infModified.matches[i].i0];
+					afterItemClass = s_levelInf.item[currentItemIndex].classData[s_infModified.matches[i].i1];
+					if (!isInfClassEqual(beforeItemClass, afterItemClass))
+					{
+						s_infModified.modifiedIndexes.push_back(s_infModified.matches[i].i1);
+					}
+				}
+
+				// 3. Test for additions. classData in after that wasn't in before.
+				for (s32 newClassIndex = 0; newClassIndex < newClassDataSize; newClassIndex++)
+				{
+					afterItemPtr = (void*)s_levelInf.item[currentItemIndex].classData[newClassIndex];
+					found = false;
+					for (s32 oldClassIndex = 0; oldClassIndex < oldClassDataSize; oldClassIndex++)
+					{
+						beforeItemPtr = s_infItemTemp.classPtr[oldClassIndex];
+						if (afterItemPtr == beforeItemPtr)
+						{
+							found = true;
+							break;
+						}
+					}
+
+					if (!found)
+					{
+						// Addition
+						s_infModified.newIndexes.push_back(newClassIndex);
+					}
+				}
+
+				if (s_infModified.deleteIndexes.size() == 0 && s_infModified.modifiedIndexes.size() == 0 && s_infModified.newIndexes.size() == 0)
+				{
+					assert(isClassIndexesMatched());
+					return; // no changes
+				}
+				
+				cmd_infModifySnapshot(LName_Inf_Change, currentItemIndex);
+			}
+		}
+		else
+		{
+			// Test for delete case
+		}
+	}
+
 	void editor_infEditEnd()
 	{
 		modifySectorGeometry();
+		findInfChangesForHistory();
+		clearInfItemTemp();
 	}
 
 	const char* c_infElevFlagNames[] =
@@ -4376,7 +4658,7 @@ namespace LevelEditor
 			}
 		}
 	}
-		
+
 	bool editor_infEdit()
 	{
 		DisplayInfo info;
@@ -4401,6 +4683,18 @@ namespace LevelEditor
 		ImGui::PushStyleColor(ImGuiCol_ModalWindowDimBg, { 0.80f, 0.80f, 0.80f, 0.15f });
 
 		bool wasPopupOpen = ImGui::IsPopupOpen("Edit INF");
+		if (!wasPopupOpen) // Runs once on open
+		{
+			// Init history things
+			clearInfItemTemp();
+			s_infItemTemp.infCount = (s32)s_levelInf.item.size();
+			if (s_infEditor.item)
+			{
+				setInfItemTemp(s_infEditor.item);
+			}
+			
+		}
+
 		if (ImGui::BeginPopupModal("Edit INF", &active, window_flags))
 		{
 			// Popups need multiple frames to "accept" the new position due to the way the imGui window position logic works.

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -559,6 +559,210 @@ namespace LevelEditor
 		client->targetSector = arg;
 	}
 
+	// Walk each member of two Editor_LevelInf structs testing for equality. Inf undo is scary.
+	bool compareLevelInfs(Editor_LevelInf& left, Editor_LevelInf& right)
+	{	
+		if (left.item.size() != right.item.size() ||
+			left.elevator.size() != right.elevator.size() ||
+			left.trigger.size() != right.trigger.size() ||
+			left.teleport.size() != right.teleport.size())
+		{
+			LE_WARNING("compareLevelInfs(): vec sizes don't match");
+			return false;
+		}
+
+		for (size_t i = 0; i < left.item.size(); i++)
+		{
+			if ((left.item[i].name != right.item[i].name) ||
+				(left.item[i].wallNum != right.item[i].wallNum))
+			{
+				LE_WARNING("compareLevelInfs(): item index %zu don't match", i);
+				return false;
+			}
+		}
+
+		for (size_t i = 0; i < left.elevator.size(); i++)
+		{
+			Editor_InfElevator* lElev = left.elevator[i];
+			Editor_InfElevator* rElev = right.elevator[i];
+
+			if (lElev->slaves.size() != rElev->slaves.size() ||
+				lElev->stops.size() != rElev->stops.size())
+			{
+				LE_WARNING("compareLevelInfs(): elev index %zu slave/stop count mismatch", i);
+				return false;
+			}
+
+
+			if (lElev->classId != rElev->classId ||
+				lElev->type != rElev->type ||
+				lElev->overrideSet != rElev->overrideSet ||
+				lElev->start != rElev->start ||
+				lElev->speed != rElev->speed ||
+				lElev->angle != rElev->angle ||
+				lElev->flags != rElev->flags ||
+				(lElev->key[0] != rElev->key[0] || lElev->key[1] != rElev->key[1]) ||
+				(lElev->center.x != rElev->center.x || lElev->center.z != rElev->center.z) ||
+				(lElev->sounds[0] != rElev->sounds[0] || lElev->sounds[1] != rElev->sounds[1] || lElev->sounds[2] != rElev->sounds[2]) ||
+				lElev->master != rElev->master ||
+				lElev->eventMask != rElev->eventMask ||
+				lElev->entityMask != rElev->entityMask)
+			{
+				LE_WARNING("compareLevelInfs(): elev index %zu don't match", i);
+				return false;
+			}
+
+			for (size_t j = 0; j < lElev->slaves.size(); j++)
+			{
+				if (lElev->slaves[j].name != rElev->slaves[j].name ||
+					lElev->slaves[j].angleOffset != rElev->slaves[j].angleOffset)
+				{
+					LE_WARNING("compareLevelInfs(): elev index %zu slave index %zu don't match", i, j);
+					return false;
+				}
+			}
+
+			for (size_t j = 0; j < lElev->stops.size(); j++)
+			{
+				Editor_InfStop* lStop = &lElev->stops[j];
+				Editor_InfStop* rStop = &rElev->stops[j];
+				if (lStop->adjoinCmd.size() != rStop->adjoinCmd.size() ||
+					lStop->textureCmd.size() != rStop->textureCmd.size() ||
+					lStop->msg.size() != rStop->msg.size() ||
+					lStop->scriptCall.size() != rStop->scriptCall.size())
+				{
+					LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu cmd vecs dont match", i, j);
+					return false;
+				}
+				
+				if (lStop->overrideSet != rStop->overrideSet ||
+					lStop->relative != rStop->relative ||
+					lStop->value != rStop->value ||
+					lStop->fromSectorFloor != rStop->fromSectorFloor ||
+					lStop->delayType != rStop->delayType ||
+					lStop->delay != rStop->delay ||
+					lStop->page != rStop->page)
+				{
+					LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu data dont match", i, j);
+					return false;
+				}
+
+				for (size_t k = 0; k < lStop->adjoinCmd.size(); k++)
+				{
+					Editor_InfAdjoinCmd* lAdj = &lStop->adjoinCmd[k];
+					Editor_InfAdjoinCmd* rAdj = &rStop->adjoinCmd[k];
+					if (lAdj->sector0 != rAdj->sector0 ||
+						lAdj->sector1 != rAdj->sector1 ||
+						lAdj->wallIndex0 != rAdj->wallIndex0 ||
+						lAdj->wallIndex1 != rAdj->wallIndex1)
+					{
+						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu adj index %zu data dont match", i, j, k);
+						return false;
+					}
+				}
+
+				for (size_t k = 0; k < lStop->textureCmd.size(); k++)
+				{
+					Editor_InfTextureCmd* lTex = &lStop->textureCmd[k];
+					Editor_InfTextureCmd* rTex = &rStop->textureCmd[k];
+					if (lTex->donorSector != rTex->donorSector ||
+						lTex->fromCeiling != rTex->fromCeiling)
+					{
+						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu tex index %zu data dont match", i, j, k);
+						return false;
+					}
+				}
+
+				for (size_t k = 0; k < lStop->msg.size(); k++)
+				{
+					Editor_InfMessage* lMsg = &lStop->msg[k];
+					Editor_InfMessage* rMsg = &rStop->msg[k];
+					if (lMsg->targetSector != rMsg->targetSector ||
+						lMsg->targetWall != rMsg->targetWall ||
+						lMsg->type != rMsg->type ||
+						lMsg->eventFlags != rMsg->eventFlags ||
+						(lMsg->arg[0] != rMsg->arg[0] || lMsg->arg[1] != rMsg->arg[1]))
+					{
+						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu msg index %zu data dont match", i, j, k);
+						return false;
+					}
+				}
+
+				for (size_t k = 0; k < lStop->scriptCall.size(); k++)
+				{
+					Editor_ScriptCall* lCall = &lStop->scriptCall[k];
+					Editor_ScriptCall* rCall = &rStop->scriptCall[k];
+					if (lCall->funcName != rCall->funcName ||
+						lCall->arg[0].value != rCall->arg[0].value ||
+						lCall->arg[1].value != rCall->arg[1].value ||
+						lCall->arg[2].value != rCall->arg[2].value ||
+						lCall->arg[3].value != rCall->arg[3].value)
+					{
+						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu script index %zu data dont match", i, j, k);
+						return false;
+					}
+				}
+			} // for elev stops
+		} // for elev
+
+		for (size_t i = 0; i < left.trigger.size(); i++)
+		{
+			Editor_InfTrigger* lTrig = left.trigger[i];
+			Editor_InfTrigger* rTrig = right.trigger[i];
+
+			if (lTrig->clients.size() != rTrig->clients.size())
+			{
+				LE_WARNING("compareLevelInfs(): trig index %zu client size not match", i);
+				return false;
+			}
+			if (lTrig->classId != rTrig->classId ||
+				lTrig->type != rTrig->type ||
+				lTrig->overrideSet != rTrig->overrideSet ||
+				lTrig->cmd != rTrig->cmd ||
+				(lTrig->arg[0] != rTrig->arg[0] || lTrig->arg[1] != rTrig->arg[1]) ||
+				lTrig->sound != rTrig->sound ||
+				lTrig->master != rTrig->master ||
+				lTrig->textId != rTrig->textId ||
+				lTrig->eventMask != rTrig->eventMask ||
+				lTrig->entityMask != rTrig->entityMask ||
+				lTrig->event != rTrig->event)
+			{
+				LE_WARNING("compareLevelInfs(): trig index %zu data not match", i);
+				return false;
+			}
+
+			for (size_t j = 0; j < lTrig->clients.size(); j++)
+			{
+				Editor_InfClient* lClient = &lTrig->clients[j];
+				Editor_InfClient* rClient = &rTrig->clients[j];
+				if (lClient->targetSector != rClient->targetSector ||
+					lClient->targetWall != rClient->targetWall ||
+					lClient->eventMask != rClient->eventMask)
+				{
+					LE_WARNING("compareLevelInfs(): trig index %zu client index %zu data not match", i, j);
+					return false;
+				}
+			}
+		} // for trig
+
+		for (size_t i = 0; i < left.teleport.size(); i++)
+		{
+			Editor_InfTeleporter* lTele = left.teleport[i];
+			Editor_InfTeleporter* rTele = right.teleport[i];
+			if (lTele->classId != rTele->classId ||
+				lTele->type != rTele->type ||
+				lTele->target != rTele->target ||
+				(lTele->dstPos.x != rTele->dstPos.x || lTele->dstPos.y != rTele->dstPos.y || lTele->dstPos.z != rTele->dstPos.z) ||
+				lTele->dstAngle != rTele->dstAngle)
+			{
+				LE_WARNING("compareLevelInfs(): tele index %zu data not match", i);
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	bool editor_parseElevatorCommand(s32 argCount, KEYWORD action, bool seqEnd, Editor_InfElevator* elev, s32& addon)
 	{
 		char* endPtr = nullptr;

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
@@ -328,8 +328,16 @@ namespace LevelEditor
 		Vec3f nrm;			// face normal.
 	};
 
+	struct INFWallTrack
+	{
+		std::string name;
+		s32 oldWall;
+		s32 newWall;
+	};
+
 	extern Editor_LevelInf s_levelInf;
 	extern InfModified s_infModified;
+	extern std::vector<INFWallTrack> s_infWallTrack;
 
 	void editor_infDestroy();
 	bool loadLevelInfFromAsset(const TFE_Editor::Asset* asset);
@@ -337,6 +345,7 @@ namespace LevelEditor
 	void editor_infEditEnd();
 	bool editor_infEdit();
 	Editor_InfItem* editor_getInfItem(const char* sectorName, s32 wallIndex);
+	std::vector<Editor_InfItem*> editor_listInfItemsByName(std::string& sectorName);
 
 	void editor_writeInfItem(std::string& outStr, const Editor_InfItem* item, const char* curTab);
 

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
@@ -329,6 +329,10 @@ namespace LevelEditor
 
 	void editor_infGetViewportControl(Editor_InfVpControl* ctrl);
 
+	s32 getClassIndex(Editor_InfItemClass classId, const void* classPtr);
+
+	bool compareLevelInfs(Editor_LevelInf& left, Editor_LevelInf& right);
+
 	const Editor_InfElevator* getElevFromClassData(const Editor_InfClass* data);
 	const Editor_InfTrigger* getTriggerFromClassData(const Editor_InfClass* data);
 	const Editor_InfTeleporter* getTeleporterFromClassData(const Editor_InfClass* data);

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
@@ -312,6 +312,7 @@ namespace LevelEditor
 
 	extern Editor_LevelInf s_levelInf;
 
+	void editor_infDestroy();
 	bool loadLevelInfFromAsset(const TFE_Editor::Asset* asset);
 	void editor_infEditBegin(const char* sectorName, s32 wallIndex = -1);
 	void editor_infEditEnd();

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
@@ -292,6 +292,24 @@ namespace LevelEditor
 		std::vector<Editor_InfTeleporter*>    teleport;
 	};
 
+	struct Editor_InfItemHistory
+	{
+		std::string name;
+		s32 wallNum = -1;
+		s32 infCount = -1;
+		std::vector<Editor_InfClass*> classData;
+		std::vector<void*> classPtr; // Pointers to original data for testing equality
+	};
+
+	// Modify INF history, index tracking
+	struct InfModified
+	{
+		std::vector<IndexPair>matches;
+		std::vector<s32>deleteIndexes; // temp var refs
+		std::vector<s32>modifiedIndexes; // s_levelInf refs
+		std::vector<s32>newIndexes; //s_levelInf refs
+	};
+
 	enum InfVpControlType
 	{
 		InfVpControl_None = 0,
@@ -311,6 +329,7 @@ namespace LevelEditor
 	};
 
 	extern Editor_LevelInf s_levelInf;
+	extern InfModified s_infModified;
 
 	void editor_infDestroy();
 	bool loadLevelInfFromAsset(const TFE_Editor::Asset* asset);
@@ -336,4 +355,9 @@ namespace LevelEditor
 	const Editor_InfElevator* getElevFromClassData(const Editor_InfClass* data);
 	const Editor_InfTrigger* getTriggerFromClassData(const Editor_InfClass* data);
 	const Editor_InfTeleporter* getTeleporterFromClassData(const Editor_InfClass* data);
+
+	void freeInfClass(Editor_InfClass* infClass);
+	Editor_InfElevator* allocElev(Editor_InfItem* item);
+	Editor_InfTrigger* allocTrigger(Editor_InfItem* item);
+	Editor_InfTeleporter* allocTeleporter(Editor_InfItem* item);
 }


### PR DESCRIPTION
Undo / redo for level INF data

Details of the changes are in each commit, grouped into reasonable chunks.

It's a bit convoluted due to the way INF is stored in memory inside of a Editor_LevelInf.

INF delete not yet implemented.

Resubmitted with commit 5 to address some things.