### PR TITLE
Add 2D scaler-shader

### DIFF
--- a/TheForceEngine/Shaders/scaler2D.vert
+++ b/TheForceEngine/Shaders/scaler2D.vert
@@ -1,0 +1,13 @@
+// Shared full screen quad vertex shader for both 2D-Scaler passes.
+// Same ScaleOffset/UV convention as blit.vert.
+uniform vec4 ScaleOffset;
+in vec2 vtx_pos;
+in vec2 vtx_uv;
+
+out vec2 Frag_UV;
+
+void main()
+{
+    Frag_UV = vtx_uv;
+    gl_Position = vec4(vtx_pos.xy * ScaleOffset.xy + ScaleOffset.zw, 0, 1);
+}

--- a/TheForceEngine/Shaders/scaler2DDeblur.frag
+++ b/TheForceEngine/Shaders/scaler2DDeblur.frag
@@ -1,0 +1,106 @@
+// 2D-Scaler - pass 2: edge-aware deblur/sharpen ("DEB" in the original .fx file).
+//
+// Ported from HLSL to GLSL. Original shader:
+//   2D-Scaler for ReShade
+//   Copyright (C) 2019 guest(r) - guest.r@gmail.com
+//   Licensed under the GNU General Public License v2 (or later).
+//
+// Reads the output of pass 1 (scaler2DResample.frag) and sharpens it back up:
+// a local 3x3 min/max envelope is computed, an edge-strength estimate decides
+// how strongly to push the center pixel towards that envelope (the "Deblur"
+// parameter scales this push), and a final edge-preserving weighted average
+// (a bilateral-style filter based on similarity to the sharpened result)
+// smooths out any leftover ringing.
+uniform sampler2D SourceImage;
+uniform vec2 PixelSize;     // 1 / window width, 1 / window height ("ReShade::PixelSize")
+uniform float FilterWidth;  // 'Filter Width' UI parameter ("o" in the original shader)
+uniform float Deblur;       // 'Deblur' UI parameter ("DBL" in the original shader)
+
+in vec2 Frag_UV;
+out vec4 Out_Color;
+
+void main()
+{
+    // Calculating texel coordinates. The original shader always scales this
+    // pass's texel size by an additional constant 1.375 relative to pass 1.
+    vec2 invSize = 1.375 * FilterWidth * PixelSize;
+
+    vec2 dx = vec2(invSize.x, 0.0);
+    vec2 dy = vec2(0.0, invSize.y);
+    vec2 g1 = vec2(invSize.x, invSize.y);
+    vec2 g2 = vec2(-invSize.x, invSize.y);
+
+    vec2 pC4 = Frag_UV;
+
+    // Reading the texels.
+    vec3 c00 = texture(SourceImage, pC4 - g1).rgb;
+    vec3 c10 = texture(SourceImage, pC4 - dy).rgb;
+    vec3 c20 = texture(SourceImage, pC4 - g2).rgb;
+    vec3 c01 = texture(SourceImage, pC4 - dx).rgb;
+    vec3 c11 = texture(SourceImage, pC4     ).rgb;
+    vec3 c21 = texture(SourceImage, pC4 + dx).rgb;
+    vec3 c02 = texture(SourceImage, pC4 + g2).rgb;
+    vec3 c12 = texture(SourceImage, pC4 + dy).rgb;
+    vec3 c22 = texture(SourceImage, pC4 + g1).rgb;
+
+    vec3 d11 = c11;
+
+    vec3 mn1 = min(min(c00, c01), c02);
+    vec3 mn2 = min(min(c10, c11), c12);
+    vec3 mn3 = min(min(c20, c21), c22);
+    vec3 mx1 = max(max(c00, c01), c02);
+    vec3 mx2 = max(max(c10, c11), c12);
+    vec3 mx3 = max(max(c20, c21), c22);
+
+    mn1 = min(min(mn1, mn2), mn3);
+    mx1 = max(max(mx1, mx2), mx3);
+
+    vec3 dif1 = abs(c11 - mn1) + 0.0001;
+    vec3 dif2 = abs(c11 - mx1) + 0.0001;
+
+    vec3 dt = vec3(1.0);
+    float d1 = dot(abs(c00 - c22), dt) + 0.0001;
+    float d2 = dot(abs(c20 - c02), dt) + 0.0001;
+    float hl = dot(abs(c01 - c21), dt) + 0.0001;
+    float vl = dot(abs(c10 - c12), dt) + 0.0001;
+
+    float dif = pow(max(d1 + d2 + hl + vl - 0.2, 0.0) / (0.25 * dot(c01 + c10 + c12 + c21, dt) + 0.33), 0.75);
+
+    dif = min(dif, 1.0);
+    float db1 = max(mix(0.0, Deblur, dif), 1.0);
+
+    dif1 = vec3(pow(dif1.x, db1), pow(dif1.y, db1), pow(dif1.z, db1));
+    dif2 = vec3(pow(dif2.x, db1), pow(dif2.y, db1), pow(dif2.z, db1));
+
+    d11 = vec3(
+        (dif1.x * mx1.x + dif2.x * mn1.x) / (dif1.x + dif2.x),
+        (dif1.y * mx1.y + dif2.y * mn1.y) / (dif1.y + dif2.y),
+        (dif1.z * mx1.z + dif2.z * mn1.z) / (dif1.z + dif2.z));
+
+    float k10 = 1.0 / (dot(abs(c10 - d11), dt) + 0.0001);
+    float k01 = 1.0 / (dot(abs(c01 - d11), dt) + 0.0001);
+    float k11 = 1.0 / (dot(abs(c11 - d11), dt) + 0.0001);
+    float k21 = 1.0 / (dot(abs(c21 - d11), dt) + 0.0001);
+    float k12 = 1.0 / (dot(abs(c12 - d11), dt) + 0.0001);
+    float k00 = 1.0 / (dot(abs(c00 - d11), dt) + 0.0001);
+    float k02 = 1.0 / (dot(abs(c02 - d11), dt) + 0.0001);
+    float k20 = 1.0 / (dot(abs(c20 - d11), dt) + 0.0001);
+    float k22 = 1.0 / (dot(abs(c22 - d11), dt) + 0.0001);
+
+    float avg = 0.025 * (k10 + k01 + k11 + k21 + k12 + k00 + k02 + k20 + k22);
+
+    k10 = max(k10 - avg, 0.0);
+    k01 = max(k01 - avg, 0.0);
+    k11 = max(k11 - avg, 0.0);
+    k21 = max(k21 - avg, 0.0);
+    k12 = max(k12 - avg, 0.0);
+    k00 = max(k00 - avg, 0.0);
+    k02 = max(k02 - avg, 0.0);
+    k20 = max(k20 - avg, 0.0);
+    k22 = max(k22 - avg, 0.0);
+
+    c11 = (k10 * c10 + k01 * c01 + k11 * c11 + k21 * c21 + k12 * c12 + k00 * c00 + k02 * c02 + k20 * c20 + k22 * c22 + 0.0001 * c11)
+        / (k10 + k01 + k11 + k21 + k12 + k00 + k02 + k20 + k22 + 0.0001);
+
+    Out_Color = vec4(c11, 1.0);
+}

--- a/TheForceEngine/Shaders/scaler2DResample.frag
+++ b/TheForceEngine/Shaders/scaler2DResample.frag
@@ -1,0 +1,90 @@
+// 2D-Scaler - pass 1: edge-aware resample ("TWODS0" in the original .fx file).
+//
+// Ported from HLSL to GLSL. Original shader:
+//   2D-Scaler for ReShade
+//   Copyright (C) 2019 guest(r) - guest.r@gmail.com
+//   Licensed under the GNU General Public License v2 (or later).
+//
+// This reads the already window-scaled game image (produced by the normal
+// TFE blit stage) and resamples it with an edge-aware, bilinear-like filter:
+// for each output texel it blends the four surrounding "diagonal" samples,
+// weighting each corner by how well it preserves local edges rather than
+// blurring across them. This softens the blocky look of a nearest-neighbor
+// upscale without turning it into a flat blur. Pass 2 (scaler2DDeblur.frag)
+// sharpens the result back up.
+uniform sampler2D SourceImage;
+uniform vec2 PixelSize;     // 1 / window width, 1 / window height ("ReShade::PixelSize")
+uniform float FilterWidth;  // 'Filter Width' UI parameter ("o" in the original shader)
+
+in vec2 Frag_UV;
+out vec4 Out_Color;
+
+// Corresponds to the "texture2d()" helper in the original shader: reads the
+// 4 diagonal neighbors around texcoord and blends them, weighting by which
+// diagonal pair better preserves the local edge.
+vec3 sampleDiagonal(vec2 texcoord, vec2 invSize)
+{
+    vec3 dt = vec3(1.0);
+
+    vec3 s00 = texture(SourceImage, texcoord + vec2(-invSize.x, -invSize.y)).rgb;
+    vec3 s20 = texture(SourceImage, texcoord + vec2( invSize.x, -invSize.y)).rgb;
+    vec3 s22 = texture(SourceImage, texcoord + vec2( invSize.x,  invSize.y)).rgb;
+    vec3 s02 = texture(SourceImage, texcoord + vec2(-invSize.x,  invSize.y)).rgb;
+
+    float m1 = dot(abs(s00 - s22), dt) + 0.001;
+    float m2 = dot(abs(s02 - s20), dt) + 0.001;
+
+    return 0.5 * (m2 * (s00 + s22) + m1 * (s02 + s20)) / (m1 + m2);
+}
+
+void main()
+{
+    vec3 dt = vec3(1.0);
+
+    // Calculating texel coordinates.
+    vec2 invSize = FilterWidth * PixelSize;
+    vec2 size = 1.0 / invSize;
+
+    vec2 pos = Frag_UV * size;
+    vec2 fp = fract(pos);
+    vec2 dx = vec2(invSize.x, 0.0);
+    vec2 dy = vec2(0.0, invSize.y);
+    vec2 g1 = vec2(invSize.x, invSize.y);
+    vec2 g2 = vec2(-invSize.x, invSize.y);
+
+    vec2 pC4 = floor(pos) * invSize + 0.5 * invSize;
+
+    // Reading the texels.
+    vec3 C0 = sampleDiagonal(pC4 - g1, invSize);
+    vec3 C1 = sampleDiagonal(pC4 - dy, invSize);
+    vec3 C2 = sampleDiagonal(pC4 - g2, invSize);
+    vec3 C3 = sampleDiagonal(pC4 - dx, invSize);
+    vec3 C4 = sampleDiagonal(pC4,      invSize);
+    vec3 C5 = sampleDiagonal(pC4 + dx, invSize);
+    vec3 C6 = sampleDiagonal(pC4 + g2, invSize);
+    vec3 C7 = sampleDiagonal(pC4 + dy, invSize);
+    vec3 C8 = sampleDiagonal(pC4 + g1, invSize);
+
+    vec3 ul, ur, dl, dr;
+    float m1, m2;
+
+    m1 = dot(abs(C0 - C4), dt) + 0.001;
+    m2 = dot(abs(C1 - C3), dt) + 0.001;
+    ul = (m2 * (C0 + C4) + m1 * (C1 + C3)) / (m1 + m2);
+
+    m1 = dot(abs(C1 - C5), dt) + 0.001;
+    m2 = dot(abs(C2 - C4), dt) + 0.001;
+    ur = (m2 * (C1 + C5) + m1 * (C2 + C4)) / (m1 + m2);
+
+    m1 = dot(abs(C3 - C7), dt) + 0.001;
+    m2 = dot(abs(C6 - C4), dt) + 0.001;
+    dl = (m2 * (C3 + C7) + m1 * (C6 + C4)) / (m1 + m2);
+
+    m1 = dot(abs(C4 - C8), dt) + 0.001;
+    m2 = dot(abs(C5 - C7), dt) + 0.001;
+    dr = (m2 * (C4 + C8) + m1 * (C5 + C7)) / (m1 + m2);
+
+    vec3 result = 0.5 * ((dr * fp.x + dl * (1.0 - fp.x)) * fp.y + (ur * fp.x + ul * (1.0 - fp.x)) * (1.0 - fp.y));
+
+    Out_Color = vec4(result, 1.0);
+}

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -3283,6 +3283,30 @@ namespace TFE_FrontEndUI
 			ImGui::SliderFloat("Spread", &graphics->bloomSpread, 0.0f, 1.0f);
 		}
 
+		// 2D-Scaler - edge-aware resample + deblur filter (ported from a
+		// ReShade shader), applied only to the game framebuffer after it has
+		// been scaled to the window - never to TFE's own ImGui front-end or
+		// main menu.
+		bool scaler2DChanged = ImGui::Checkbox("2D-Scaler", &graphics->scaler2DEnabled);
+		if (graphics->scaler2DEnabled)
+		{
+			if (ImGui::Button("Reset To Default###Scaler2D"))
+			{
+				graphics->scaler2DFilterWidth = 0.750f;
+				graphics->scaler2DDeblur = 3.000f;
+				scaler2DChanged = true;
+			}
+
+			ImGui::SetNextItemWidth(196 * s_uiScale);
+			scaler2DChanged |= ImGui::SliderFloat("Filter Width", &graphics->scaler2DFilterWidth, 0.25f, 2.0f);
+			ImGui::SetNextItemWidth(196 * s_uiScale);
+			scaler2DChanged |= ImGui::SliderFloat("Deblur", &graphics->scaler2DDeblur, 1.0f, 5.0f);
+		}
+		if (scaler2DChanged)
+		{
+			TFE_RenderBackend::setScaler2DOptions(graphics->scaler2DEnabled, graphics->scaler2DFilterWidth, graphics->scaler2DDeblur);
+		}
+
 		const ColorCorrection colorCorrection = { graphics->brightness, graphics->contrast, graphics->saturation, graphics->gamma };
 		TFE_RenderBackend::setColorCorrection(graphics->colorCorrection, &colorCorrection, bloomChanged);
 	}

--- a/TheForceEngine/TFE_PostProcess/postprocess.cpp
+++ b/TheForceEngine/TFE_PostProcess/postprocess.cpp
@@ -261,6 +261,15 @@ namespace TFE_PostProcess
 			}
 
 			Shader* shader = effect->m_shader;
+			if (!shader)
+			{
+				// Defensive guard: an effect whose init() failed to load/compile
+				// its shader(s) would otherwise leave m_shader uninitialized,
+				// crashing here (and, on some GPU drivers, inside the driver
+				// itself rather than with a clean access violation in TFE).
+				TFE_System::logWrite(LOG_ERROR, "PostFX", "Effect instance has NULL shader. Index = %u", e);
+				continue;
+			}
 			shader->bind();
 
 			if (curRenderTarget != effectInst->output)

--- a/TheForceEngine/TFE_PostProcess/postprocesseffect.h
+++ b/TheForceEngine/TFE_PostProcess/postprocesseffect.h
@@ -39,6 +39,9 @@ public:
 	virtual void setEffectState() = 0;
 
 public:
-	Shader* m_shader;
-	s32 m_scaleOffsetId;
+	// Defaulted to null/-1 so that an effect whose init() fails partway
+	// (e.g. a shader that failed to compile) leaves m_shader in a safely
+	// checkable state instead of uninitialized garbage.
+	Shader* m_shader = nullptr;
+	s32 m_scaleOffsetId = -1;
 };

--- a/TheForceEngine/TFE_PostProcess/scaler2DDeblur.cpp
+++ b/TheForceEngine/TFE_PostProcess/scaler2DDeblur.cpp
@@ -1,0 +1,40 @@
+#include "scaler2DDeblur.h"
+#include "postprocess.h"
+#include <TFE_RenderBackend/renderBackend.h>
+#include <TFE_System/profiler.h>
+
+bool Scaler2DDeblur::init()
+{
+	if (!m_shaderInternal.load("Shaders/scaler2D.vert", "Shaders/scaler2DDeblur.frag"))
+	{
+		return false;
+	}
+	m_shaderInternal.bindTextureNameToSlot("SourceImage", 0);
+	m_pixelSizeId = m_shaderInternal.getVariableId("PixelSize");
+	m_filterWidthId = m_shaderInternal.getVariableId("FilterWidth");
+	m_deblurId = m_shaderInternal.getVariableId("Deblur");
+	setupShader();
+	return true;
+}
+
+void Scaler2DDeblur::destroy()
+{
+	m_shaderInternal.destroy();
+}
+
+void Scaler2DDeblur::setEffectState()
+{
+	TFE_RenderState::setStateEnable(false, STATE_CULLING | STATE_BLEND | STATE_DEPTH_TEST);
+	if (m_shader)
+	{
+		m_shader->setVariable(m_pixelSizeId, SVT_VEC2, m_pixelSize);
+		m_shader->setVariable(m_filterWidthId, SVT_SCALAR, &m_filterWidth);
+		m_shader->setVariable(m_deblurId, SVT_SCALAR, &m_deblur);
+	}
+}
+
+void Scaler2DDeblur::setupShader()
+{
+	m_shader = &m_shaderInternal;
+	m_scaleOffsetId = m_shader->getVariableId("ScaleOffset");
+}

--- a/TheForceEngine/TFE_PostProcess/scaler2DDeblur.h
+++ b/TheForceEngine/TFE_PostProcess/scaler2DDeblur.h
@@ -1,0 +1,46 @@
+#pragma once
+//////////////////////////////////////////////////////////////////////
+// 2D-Scaler (pass 2: edge-aware deblur/sharpen).
+//
+// GPU port of the "2D-Scaler" ReShade shader by guest(r) (2019),
+// released under the GNU GPL v2 (or later). Original source:
+// https://github.com/guestrr (ReShade shader repository "2D-Scaler.fx").
+//
+// This is pass 2 of 2 ("DEB" in the original .fx file). It reads the
+// output of Scaler2DResample and sharpens it back up in an edge-aware
+// way (a local min/max clamp driven deblur), counteracting the softening
+// introduced by pass 1 while avoiding ringing on flat regions.
+//
+// Like Bloom, this only affects the game framebuffer post process chain
+// and never TFE's own ImGui front-end or main menu (see
+// TFE_RenderBackend::swap()).
+//////////////////////////////////////////////////////////////////////
+
+#include <TFE_System/types.h>
+#include "postprocesseffect.h"
+
+class Scaler2DDeblur : public PostProcessEffect
+{
+public:
+	bool init() override;
+	void destroy() override;
+	void setEffectState() override;
+
+	// 'Filter Width' parameter from the original shader (ui_min = 0.25, ui_max = 2.0).
+	void setFilterWidth(f32 filterWidth) { m_filterWidth = filterWidth; }
+	// 'Deblur' parameter from the original shader (ui_min = 1.0, ui_max = 5.0).
+	void setDeblur(f32 deblur) { m_deblur = deblur; }
+	// Reciprocal of the *window* resolution this pass operates on (ReShade::PixelSize equivalent).
+	void setPixelSize(f32 invWidth, f32 invHeight) { m_pixelSize[0] = invWidth; m_pixelSize[1] = invHeight; }
+
+private:
+	Shader m_shaderInternal;
+	s32 m_pixelSizeId = -1;
+	s32 m_filterWidthId = -1;
+	s32 m_deblurId = -1;
+	f32 m_filterWidth = 0.75f;
+	f32 m_deblur = 3.0f;
+	f32 m_pixelSize[2] = { 1.0f, 1.0f };
+
+	void setupShader();
+};

--- a/TheForceEngine/TFE_PostProcess/scaler2DResample.cpp
+++ b/TheForceEngine/TFE_PostProcess/scaler2DResample.cpp
@@ -1,0 +1,38 @@
+#include "scaler2DResample.h"
+#include "postprocess.h"
+#include <TFE_RenderBackend/renderBackend.h>
+#include <TFE_System/profiler.h>
+
+bool Scaler2DResample::init()
+{
+	if (!m_shaderInternal.load("Shaders/scaler2D.vert", "Shaders/scaler2DResample.frag"))
+	{
+		return false;
+	}
+	m_shaderInternal.bindTextureNameToSlot("SourceImage", 0);
+	m_pixelSizeId = m_shaderInternal.getVariableId("PixelSize");
+	m_filterWidthId = m_shaderInternal.getVariableId("FilterWidth");
+	setupShader();
+	return true;
+}
+
+void Scaler2DResample::destroy()
+{
+	m_shaderInternal.destroy();
+}
+
+void Scaler2DResample::setEffectState()
+{
+	TFE_RenderState::setStateEnable(false, STATE_CULLING | STATE_BLEND | STATE_DEPTH_TEST);
+	if (m_shader)
+	{
+		m_shader->setVariable(m_pixelSizeId, SVT_VEC2, m_pixelSize);
+		m_shader->setVariable(m_filterWidthId, SVT_SCALAR, &m_filterWidth);
+	}
+}
+
+void Scaler2DResample::setupShader()
+{
+	m_shader = &m_shaderInternal;
+	m_scaleOffsetId = m_shader->getVariableId("ScaleOffset");
+}

--- a/TheForceEngine/TFE_PostProcess/scaler2DResample.h
+++ b/TheForceEngine/TFE_PostProcess/scaler2DResample.h
@@ -1,0 +1,43 @@
+#pragma once
+//////////////////////////////////////////////////////////////////////
+// 2D-Scaler (pass 1: edge-aware resample).
+//
+// GPU port of the "2D-Scaler" ReShade shader by guest(r) (2019),
+// released under the GNU GPL v2 (or later). Original source:
+// https://github.com/guestrr (ReShade shader repository "2D-Scaler.fx").
+//
+// This is pass 1 of 2 ("TWODS0" in the original .fx file). It resamples
+// the already window-scaled game image with an edge-aware bilinear-like
+// filter that softens the blocky look of nearest-neighbor upscaled pixel
+// art, without fully blurring away sharp edges. Pass 2 (Scaler2DDeblur)
+// then sharpens the result back up.
+//
+// Like Bloom, this only affects the game framebuffer post process chain
+// and never TFE's own ImGui front-end or main menu (see
+// TFE_RenderBackend::swap()).
+//////////////////////////////////////////////////////////////////////
+
+#include <TFE_System/types.h>
+#include "postprocesseffect.h"
+
+class Scaler2DResample : public PostProcessEffect
+{
+public:
+	bool init() override;
+	void destroy() override;
+	void setEffectState() override;
+
+	// 'Filter Width' parameter from the original shader (ui_min = 0.25, ui_max = 2.0).
+	void setFilterWidth(f32 filterWidth) { m_filterWidth = filterWidth; }
+	// Reciprocal of the *window* resolution this pass operates on (ReShade::PixelSize equivalent).
+	void setPixelSize(f32 invWidth, f32 invHeight) { m_pixelSize[0] = invWidth; m_pixelSize[1] = invHeight; }
+
+private:
+	Shader m_shaderInternal;
+	s32 m_pixelSizeId = -1;
+	s32 m_filterWidthId = -1;
+	f32 m_filterWidth = 0.75f;
+	f32 m_pixelSize[2] = { 1.0f, 1.0f };
+
+	void setupShader();
+};

--- a/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderBackend.cpp
+++ b/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderBackend.cpp
@@ -11,6 +11,8 @@
 #include <TFE_PostProcess/bloomThreshold.h>
 #include <TFE_PostProcess/bloomDownsample.h>
 #include <TFE_PostProcess/bloomMerge.h>
+#include <TFE_PostProcess/scaler2DResample.h>
+#include <TFE_PostProcess/scaler2DDeblur.h>
 #include <TFE_PostProcess/postprocess.h>
 #include "renderTarget.h"
 #include "screenCapture.h"
@@ -64,16 +66,33 @@ namespace TFE_RenderBackend
 	static f32 s_clearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
 	static u32 s_rtWidth, s_rtHeight;
 
+	// 2D-Scaler state - see setupScaler2DTargets()/setScaler2DOptions().
+	static bool s_scaler2DEnable = false;
+	static bool s_scaler2DShadersValid = false;
+	static f32  s_scaler2DFilterWidth = 0.750f;
+	static f32  s_scaler2DDeblur = 3.000f;
+
 	static Blit* s_postEffectBlit;
 	static BloomThreshold* s_bloomTheshold;
 	static BloomDownsample* s_bloomDownsample;
 	static BloomMerge* s_bloomMerge;
 	static std::vector<SDL_Rect> s_displayBounds;
 
+	// 2D-Scaler post effects and its two window-resolution intermediate
+	// render targets (ping-ponged: blit -> A -> resample -> B -> deblur -> screen).
+	static Scaler2DResample* s_scaler2DResample = nullptr;
+	static Scaler2DDeblur*   s_scaler2DDeblurEffect = nullptr;
+	static RenderTarget* s_scaler2DTargetA = nullptr;
+	static TextureGpu*   s_scaler2DTextureA = nullptr;
+	static RenderTarget* s_scaler2DTargetB = nullptr;
+	static TextureGpu*   s_scaler2DTextureB = nullptr;
+
 	static SDL_Window* s_window = nullptr;
 
 	void drawVirtualDisplay();
 	void setupPostEffectChain(bool useDynamicTexture, bool useBloom);
+	void freeScaler2DTargets();
+	void setupScaler2DTargets();
 
 	static GLuint s_globalVAO = 0;
 	static bool s_isMacOS = false;
@@ -327,6 +346,22 @@ namespace TFE_RenderBackend
 		s_bloomMerge = new BloomMerge();
 		s_bloomMerge->init();
 
+		s_scaler2DResample = new Scaler2DResample();
+		const bool scaler2DResampleOk = s_scaler2DResample->init();
+
+		s_scaler2DDeblurEffect = new Scaler2DDeblur();
+		const bool scaler2DDeblurOk = s_scaler2DDeblurEffect->init();
+
+		// If either shader failed to load/compile, permanently disable the
+		// 2D-Scaler feature for this session rather than risk running the post
+		// process chain with an invalid/uninitialized shader (which can crash,
+		// particularly on some GPU drivers). See setupScaler2DTargets().
+		s_scaler2DShadersValid = scaler2DResampleOk && scaler2DDeblurOk;
+		if (!s_scaler2DShadersValid)
+		{
+			TFE_System::logWrite(LOG_ERROR, "RenderBackend", "2D-Scaler shaders failed to load - the filter has been disabled for this session. Check %s for shader compile errors.", "the_force_engine_log.txt");
+		}
+
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClearDepth(0.0f);
 
@@ -368,6 +403,16 @@ namespace TFE_RenderBackend
 		s_bloomMerge->destroy();
 		delete s_bloomMerge;
 		s_bloomMerge = nullptr;
+
+		s_scaler2DResample->destroy();
+		delete s_scaler2DResample;
+		s_scaler2DResample = nullptr;
+
+		s_scaler2DDeblurEffect->destroy();
+		delete s_scaler2DDeblurEffect;
+		s_scaler2DDeblurEffect = nullptr;
+
+		freeScaler2DTargets();
 
 		TFE_PostProcess::destroy();
 		TFE_Ui::shutdown();
@@ -497,6 +542,7 @@ namespace TFE_RenderBackend
 			windowSettings->baseHeight = height;
 		}
 		glViewport(0, 0, width, height);
+		setupScaler2DTargets();
 		setupPostEffectChain(!s_useRenderTarget, s_bloomEnable);
 
 		s_screenCapture->resize(width, height);
@@ -632,6 +678,7 @@ namespace TFE_RenderBackend
 		}
 
 		glViewport(0, 0, m_windowState.width, m_windowState.height);
+		setupScaler2DTargets();
 		setupPostEffectChain(!s_useRenderTarget, s_bloomEnable);
 		s_screenCapture->resize(m_windowState.width, m_windowState.height);
 	}
@@ -738,6 +785,14 @@ namespace TFE_RenderBackend
 		s_gpuColorConvert = (vdispInfo.flags & VDISP_GPU_COLOR_CONVERT) != 0;
 		s_useRenderTarget = (vdispInfo.flags & VDISP_RENDER_TARGET) != 0;
 		s_bloomEnable = graphicsSettings->bloomEnabled && s_useRenderTarget;
+
+		s_scaler2DEnable = graphicsSettings->scaler2DEnabled;
+		s_scaler2DFilterWidth = graphicsSettings->scaler2DFilterWidth;
+		s_scaler2DDeblur = graphicsSettings->scaler2DDeblur;
+		s_scaler2DResample->setFilterWidth(s_scaler2DFilterWidth);
+		s_scaler2DDeblurEffect->setFilterWidth(s_scaler2DFilterWidth);
+		s_scaler2DDeblurEffect->setDeblur(s_scaler2DDeblur);
+		setupScaler2DTargets();
 
 		return recreateDisplay(true);
 	}
@@ -871,6 +926,27 @@ namespace TFE_RenderBackend
 		}
 	}
 
+	void setScaler2DOptions(bool enabled, f32 filterWidth, f32 deblur)
+	{
+		filterWidth = std::max(0.25f, std::min(2.0f, filterWidth));
+		deblur = std::max(1.0f, std::min(5.0f, deblur));
+
+		const bool targetsNeedRebuild = (enabled != s_scaler2DEnable);
+
+		s_scaler2DEnable = enabled;
+		s_scaler2DFilterWidth = filterWidth;
+		s_scaler2DDeblur = deblur;
+		s_scaler2DResample->setFilterWidth(filterWidth);
+		s_scaler2DDeblurEffect->setFilterWidth(filterWidth);
+		s_scaler2DDeblurEffect->setDeblur(deblur);
+
+		if (targetsNeedRebuild)
+		{
+			setupScaler2DTargets();
+			setupPostEffectChain(!s_useRenderTarget, s_bloomEnable);
+		}
+	}
+
 	void drawVirtualDisplay()
 	{
 		TFE_ZONE("Draw Virtual Display");
@@ -880,6 +956,29 @@ namespace TFE_RenderBackend
 		if (s_displayMode != DMODE_STRETCH)
 		{
 			glClear(GL_COLOR_BUFFER_BIT);
+
+			// When the 2D-Scaler is active, the final blit stage below no longer
+			// writes directly to the screen - it writes to s_scaler2DTargetA
+			// instead (see setupPostEffectChain()). That target needs the same
+			// letterbox/pillarbox clear the screen would otherwise get, since the
+			// blit only covers its aspect-corrected sub-rect, not the full target.
+			// RenderTarget::clear() clears whatever framebuffer is CURRENTLY
+			// bound rather than binding its own, so its own FBO must be bound
+			// explicitly first - otherwise this clears the screen a second time
+			// and leaves target A's letterbox/pillarbox area filled with
+			// whatever was previously in that GPU memory.
+			if (s_scaler2DEnable && s_scaler2DTargetA)
+			{
+				const f32 black[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+				bindRenderTarget(s_scaler2DTargetA);
+				clearRenderTarget(s_scaler2DTargetA, black);
+				// Not using the unbindRenderTarget() wrapper here deliberately -
+				// it also drives the pending-screenshot-copy side effect, which
+				// must only fire once for the frame's actual final image, not
+				// for this internal clear-then-restore step.
+				RenderTarget::unbind();
+				glViewport(0, 0, m_windowState.width, m_windowState.height);
+			}
 		}
 		TFE_PostProcess::execute();
 	}
@@ -1152,6 +1251,12 @@ namespace TFE_RenderBackend
 		}
 		TFE_PostProcess::clearEffectStack();
 
+		// When the 2D-Scaler is enabled, the normal final blit below writes to
+		// an intermediate window-resolution target instead of the screen, so
+		// the resample + deblur passes appended further down can process it.
+		const bool useScaler2D = s_scaler2DEnable && s_scaler2DTargetA && s_scaler2DTargetB;
+		RenderTargetHandle finalOutput = useScaler2D ? RenderTargetHandle(s_scaler2DTargetA) : nullptr;
+
 		if (useDynamicTexture)
 		{
 			const PostEffectInput blitInputs[] =
@@ -1159,7 +1264,7 @@ namespace TFE_RenderBackend
 				{ PTYPE_DYNAMIC_TEX, s_virtualDisplay },
 				{ PTYPE_DYNAMIC_TEX, s_palette }
 			};
-			TFE_PostProcess::appendEffect(s_postEffectBlit, TFE_ARRAYSIZE(blitInputs), blitInputs, nullptr, x, y, w, h);
+			TFE_PostProcess::appendEffect(s_postEffectBlit, TFE_ARRAYSIZE(blitInputs), blitInputs, finalOutput, x, y, w, h);
 		}
 		else if (useBloom)
 		{
@@ -1171,7 +1276,7 @@ namespace TFE_RenderBackend
 				{ PTYPE_TEXTURE, (void*)s_bloomTextures[s_bloomBufferCount-1] },
 				{ PTYPE_DYNAMIC_TEX, s_palette }
 			};
-			TFE_PostProcess::appendEffect(s_postEffectBlit, TFE_ARRAYSIZE(blitInputs), blitInputs, nullptr, x, y, w, h);
+			TFE_PostProcess::appendEffect(s_postEffectBlit, TFE_ARRAYSIZE(blitInputs), blitInputs, finalOutput, x, y, w, h);
 		}
 		else
 		{
@@ -1180,8 +1285,89 @@ namespace TFE_RenderBackend
 				{ PTYPE_TEXTURE, (void*)s_virtualRenderTarget->getTexture() },
 				{ PTYPE_DYNAMIC_TEX, s_palette }
 			};
-			TFE_PostProcess::appendEffect(s_postEffectBlit, TFE_ARRAYSIZE(blitInputs), blitInputs, nullptr, x, y, w, h);
+			TFE_PostProcess::appendEffect(s_postEffectBlit, TFE_ARRAYSIZE(blitInputs), blitInputs, finalOutput, x, y, w, h);
 		}
+
+		if (useScaler2D)
+		{
+			// Both passes operate on the *whole* window-resolution image (like
+			// the original ReShade shader operating on BUFFER_WIDTH/HEIGHT),
+			// not just the aspect-corrected game rect, so letterbox/pillarbox
+			// bars get resampled/deblurred too (harmless, since they're black).
+			const s32 fullW = m_windowState.width;
+			const s32 fullH = m_windowState.height;
+
+			const PostEffectInput resampleInputs[] =
+			{
+				{ PTYPE_TEXTURE, (void*)s_scaler2DTargetA->getTexture() }
+			};
+			TFE_PostProcess::appendEffect(s_scaler2DResample, TFE_ARRAYSIZE(resampleInputs), resampleInputs,
+				s_scaler2DTargetB, 0, 0, fullW, fullH);
+
+			const PostEffectInput deblurInputs[] =
+			{
+				{ PTYPE_TEXTURE, (void*)s_scaler2DTargetB->getTexture() }
+			};
+			TFE_PostProcess::appendEffect(s_scaler2DDeblurEffect, TFE_ARRAYSIZE(deblurInputs), deblurInputs,
+				nullptr, 0, 0, fullW, fullH);
+		}
+	}
+
+	// Free any previously allocated 2D-Scaler render targets/textures.
+	void freeScaler2DTargets()
+	{
+		delete s_scaler2DTargetA;
+		delete s_scaler2DTextureA;
+		delete s_scaler2DTargetB;
+		delete s_scaler2DTextureB;
+		s_scaler2DTargetA = nullptr;
+		s_scaler2DTextureA = nullptr;
+		s_scaler2DTargetB = nullptr;
+		s_scaler2DTextureB = nullptr;
+	}
+
+	// (Re)allocates the 2D-Scaler's two window-resolution intermediate render
+	// targets. Must be called whenever the window is resized/fullscreen is
+	// toggled, or the filter is enabled/disabled, before setupPostEffectChain()
+	// so it can reference the up to date targets.
+	void setupScaler2DTargets()
+	{
+		freeScaler2DTargets();
+		if (!s_scaler2DEnable || !s_scaler2DShadersValid) { return; }
+
+		const u32 w = (u32)m_windowState.width;
+		const u32 h = (u32)m_windowState.height;
+		if (w == 0 || h == 0) { return; }
+
+		// The shader relies on hardware bilinear filtering when sampling at
+		// sub-texel offsets, so both intermediate targets need linear filtering
+		// (unlike the virtual display, which uses nearest to keep pixel art crisp).
+		s_scaler2DTextureA = new TextureGpu();
+		s_scaler2DTextureA->create(w, h, TexFormat::TEX_RGBA8, false, MAG_FILTER_LINEAR);
+		s_scaler2DTextureA->setFilter(MAG_FILTER_LINEAR, MIN_FILTER_LINEAR);
+		s_scaler2DTargetA = new RenderTarget();
+		if (!s_scaler2DTargetA->create(1, &s_scaler2DTextureA, false))
+		{
+			TFE_System::logWrite(LOG_ERROR, "RenderBackend", "Failed to create 2D-Scaler render target A (%u x %u).", w, h);
+			freeScaler2DTargets();
+			return;
+		}
+
+		s_scaler2DTextureB = new TextureGpu();
+		s_scaler2DTextureB->create(w, h, TexFormat::TEX_RGBA8, false, MAG_FILTER_LINEAR);
+		s_scaler2DTextureB->setFilter(MAG_FILTER_LINEAR, MIN_FILTER_LINEAR);
+		s_scaler2DTargetB = new RenderTarget();
+		if (!s_scaler2DTargetB->create(1, &s_scaler2DTextureB, false))
+		{
+			TFE_System::logWrite(LOG_ERROR, "RenderBackend", "Failed to create 2D-Scaler render target B (%u x %u).", w, h);
+			freeScaler2DTargets();
+			return;
+		}
+
+		const f32 invW = 1.0f / f32(w);
+		const f32 invH = 1.0f / f32(h);
+		s_scaler2DResample->setPixelSize(invW, invH);
+		s_scaler2DDeblurEffect->setPixelSize(invW, invH);
 	}
 
 	void bindGlobalVAO(void)

--- a/TheForceEngine/TFE_RenderBackend/renderBackend.h
+++ b/TheForceEngine/TFE_RenderBackend/renderBackend.h
@@ -164,6 +164,11 @@ namespace TFE_RenderBackend
 	// Toggle bloom - but only the final post process.
 	void bloomPostEnable(bool enable = true);
 
+	// Enable/disable the 2D-Scaler filter (edge-aware resample + deblur) and
+	// set its parameters. Like bloom, this only affects the game framebuffer
+	// post process chain and never TFE's own ImGui front-end.
+	void setScaler2DOptions(bool enabled, f32 filterWidth, f32 deblur);
+
 	// Generic triangle draw.
 	// triCount : number of triangles to draw.
 	// indexStride : index buffer stride in bytes.

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -469,6 +469,10 @@ namespace TFE_Settings
 		writeKeyValue_Float(settings, "bloomStrength", s_graphicsSettings.bloomStrength);
 		writeKeyValue_Float(settings, "bloomSpread", s_graphicsSettings.bloomSpread);
 
+		writeKeyValue_Bool(settings, "scaler2DEnabled", s_graphicsSettings.scaler2DEnabled);
+		writeKeyValue_Float(settings, "scaler2DFilterWidth", s_graphicsSettings.scaler2DFilterWidth);
+		writeKeyValue_Float(settings, "scaler2DDeblur", s_graphicsSettings.scaler2DDeblur);
+
 		writeKeyValue_Int(settings, "renderer", s_graphicsSettings.rendererIndex);
 		writeKeyValue_Int(settings, "colorMode", s_graphicsSettings.colorMode);
 		writeKeyValue_Int(settings, "skyMode", s_graphicsSettings.skyMode);
@@ -895,6 +899,18 @@ namespace TFE_Settings
 		else if (strcasecmp("bloomSpread", key) == 0)
 		{
 			s_graphicsSettings.bloomSpread = parseFloat(value);
+		}
+		else if (strcasecmp("scaler2DEnabled", key) == 0)
+		{
+			s_graphicsSettings.scaler2DEnabled = parseBool(value);
+		}
+		else if (strcasecmp("scaler2DFilterWidth", key) == 0)
+		{
+			s_graphicsSettings.scaler2DFilterWidth = parseFloat(value);
+		}
+		else if (strcasecmp("scaler2DDeblur", key) == 0)
+		{
+			s_graphicsSettings.scaler2DDeblur = parseFloat(value);
 		}
 		else if (strcasecmp("renderer", key) == 0)
 		{

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -106,6 +106,15 @@ struct TFE_Settings_Graphics
 	f32  bloomStrength = 0.4f;
 	f32  bloomSpread = 0.6f;
 
+	// 2D-Scaler options.
+	// Edge-aware resample + deblur filter (ported from the "2D-Scaler" ReShade
+	// shader by guest(r)), applied only to the game framebuffer after it has
+	// been scaled to the window - never to TFE's own ImGui front-end or main
+	// menu (see TFE_RenderBackend::swap()).
+	bool scaler2DEnabled = false;
+	f32  scaler2DFilterWidth = 0.750f;	// 'Filter Width' - valid range [0.25, 2.0].
+	f32  scaler2DDeblur = 3.000f;		// 'Deblur' - valid range [1.0, 5.0].
+
 	// Sky (Ignored when using the software renderer)
 	s32  skyMode = SKYMODE_CYLINDER;
 };

--- a/TheForceEngine/TheForceEngine.vcxproj
+++ b/TheForceEngine/TheForceEngine.vcxproj
@@ -700,6 +700,8 @@ echo ^)";
     <ClInclude Include="TFE_PostProcess\blit.h" />
     <ClInclude Include="TFE_PostProcess\bloomDownsample.h" />
     <ClInclude Include="TFE_PostProcess\bloomMerge.h" />
+    <ClInclude Include="TFE_PostProcess\scaler2DResample.h" />
+    <ClInclude Include="TFE_PostProcess\scaler2DDeblur.h" />
     <ClInclude Include="TFE_PostProcess\bloomThreshold.h" />
     <ClInclude Include="TFE_PostProcess\overlay.h" />
     <ClInclude Include="TFE_PostProcess\postprocess.h" />
@@ -1094,6 +1096,8 @@ echo ^)";
     <ClCompile Include="TFE_PostProcess\blit.cpp" />
     <ClCompile Include="TFE_PostProcess\bloomDownsample.cpp" />
     <ClCompile Include="TFE_PostProcess\bloomMerge.cpp" />
+    <ClCompile Include="TFE_PostProcess\scaler2DResample.cpp" />
+    <ClCompile Include="TFE_PostProcess\scaler2DDeblur.cpp" />
     <ClCompile Include="TFE_PostProcess\bloomThreshold.cpp" />
     <ClCompile Include="TFE_PostProcess\overlay.cpp" />
     <ClCompile Include="TFE_PostProcess\postprocess.cpp" />
@@ -1183,6 +1187,9 @@ echo ^)";
     <None Include="Shaders\bloomDownsample.frag" />
     <None Include="Shaders\bloomMerge.frag" />
     <None Include="Shaders\bloomThreshold.frag" />
+    <None Include="Shaders\scaler2D.vert" />
+    <None Include="Shaders\scaler2DResample.frag" />
+    <None Include="Shaders\scaler2DDeblur.frag" />
     <None Include="Shaders\gpu_render_modelHologram.frag" />
     <None Include="Shaders\gpu_render_modelHologram.vert" />
     <None Include="Shaders\gpu_render_modelSolid.frag" />

--- a/TheForceEngine/TheForceEngine.vcxproj.filters
+++ b/TheForceEngine/TheForceEngine.vcxproj.filters
@@ -1048,6 +1048,12 @@
     <ClInclude Include="TFE_PostProcess\bloomMerge.h">
       <Filter>Source\TFE_PostProcess</Filter>
     </ClInclude>
+    <ClInclude Include="TFE_PostProcess\scaler2DResample.h">
+      <Filter>Source\TFE_PostProcess</Filter>
+    </ClInclude>
+    <ClInclude Include="TFE_PostProcess\scaler2DDeblur.h">
+      <Filter>Source\TFE_PostProcess</Filter>
+    </ClInclude>
     <ClInclude Include="TFE_Jedi\Level\levelBin.h">
       <Filter>Source\TFE_Jedi\Level</Filter>
     </ClInclude>
@@ -2232,6 +2238,12 @@
     <ClCompile Include="TFE_PostProcess\bloomMerge.cpp">
       <Filter>Source\TFE_PostProcess</Filter>
     </ClCompile>
+    <ClCompile Include="TFE_PostProcess\scaler2DResample.cpp">
+      <Filter>Source\TFE_PostProcess</Filter>
+    </ClCompile>
+    <ClCompile Include="TFE_PostProcess\scaler2DDeblur.cpp">
+      <Filter>Source\TFE_PostProcess</Filter>
+    </ClCompile>
     <ClCompile Include="TFE_Jedi\Level\levelBin.cpp">
       <Filter>Source\TFE_Jedi\Level</Filter>
     </ClCompile>
@@ -2866,6 +2878,15 @@
       <Filter>Source\Shaders</Filter>
     </None>
     <None Include="Shaders\bloom.vert">
+      <Filter>Source\Shaders</Filter>
+    </None>
+    <None Include="Shaders\scaler2D.vert">
+      <Filter>Source\Shaders</Filter>
+    </None>
+    <None Include="Shaders\scaler2DResample.frag">
+      <Filter>Source\Shaders</Filter>
+    </None>
+    <None Include="Shaders\scaler2DDeblur.frag">
       <Filter>Source\Shaders</Filter>
     </None>
     <None Include="Shaders\tri3dWall.frag">


### PR DESCRIPTION
ported a 2d-scaler shader to the forceengine (gpl compatible, atttributions in code)
- a bit of a vaseline filter but makes the edges of sprites much nicer
- can be tuned in settings (tested/usable default values)
- disabled by default so it is just an option

ofc this is fully tested (all render modes) and [testbuild ](https://github.com/000MDK/TheForceEngine/releases/tag/scaler2d)available